### PR TITLE
Make broker's session ID starts from 2

### DIFF
--- a/broker/l2tp_broker.py
+++ b/broker/l2tp_broker.py
@@ -374,7 +374,7 @@ class Tunnel(gevent.Greenlet):
     self.external_port = port
     self.limits = Limits(self)
     self.sessions = {}
-    self.next_session_id = 1
+    self.next_session_id = 2
     self.keep_alive()
 
   def setup(self):


### PR DESCRIPTION
According to RFC3931 chapter 4.1, endpoints should use different
session IDs. However the broker's ID starts from 1 and the client
is using 1 as session ID all the time, therefore the very first
tunnel for the broker will have a session that the endpoints are
having the same session ID.
