### PR TITLE
Update server.rst

### DIFF
--- a/docs/server.rst
+++ b/docs/server.rst
@@ -57,7 +57,7 @@ not affect the versions that are installed for Tunneldigger.
 
 You can install all of the above simply by running on Debian::
 
-    sudo apt-get install iproute bridge-utils libnetfilter-conntrack3 python-dev libevent-dev ebtables python-virtualenv
+    sudo apt-get install iproute bridge-utils libnetfilter-conntrack3 python-dev libevent-dev ebtables python-virtualenv libnl-dev libpopt-dev
 
 and for Fedora you can use this command::
 


### PR DESCRIPTION
I was getting this error message when building client on Ubuntu 12.04 server:
netlink/netlink.h: No such file or directory

After installing additional packages "libnl-dev libpopt-dev" compile was successful.
