### PR TITLE
client: remove faulty send in prepare_message

### DIFF
--- a/client/l2tp_client.c
+++ b/client/l2tp_client.c
@@ -541,11 +541,6 @@ void context_prepare_packet(l2tp_context *ctx, unsigned char *buf, uint8_t type,
   // when used over port 53
   if (L2TP_CONTROL_SIZE + len < 12)
     len += 12 - L2TP_CONTROL_SIZE - len;
-
-  // Send the packet
-  if (send(ctx->fd, buf, L2TP_CONTROL_SIZE + len, 0) < 0) {
-    syslog(LOG_WARNING, "Failed to send() in prepare packet (errno=%d, type=%x)!", errno, type);
-  }
 }
 
 void context_send_reliable_packet(l2tp_context *ctx, uint8_t type, char *payload, uint8_t len)


### PR DESCRIPTION
This function should only prepare the message rather than send it. It's called
by context_send_packet or context_send_reliable_packet which sends the message
after prepare_message runs over it.
