### PR TITLE
Fixing string length argument in setsockopt call as per @juul's catch.

### DIFF
--- a/client/l2tp_client.c
+++ b/client/l2tp_client.c
@@ -334,7 +334,7 @@ int context_reinitialize(l2tp_context *ctx)
   if (ctx->force_iface) {
     int rc;
 
-    rc = setsockopt(ctx->fd, SOL_SOCKET, SO_BINDTODEVICE, ctx->force_iface, strlen(ctx->force_iface));
+    rc = setsockopt(ctx->fd, SOL_SOCKET, SO_BINDTODEVICE, ctx->force_iface, strlen(ctx->force_iface) + 1);
     if (rc != 0) {
       syslog(LOG_ERR, "Failed to bind to device!");
       return -1;


### PR DESCRIPTION
@Juul mentioned that setsockopt expects a null terminated string, and that `strlen(ctx->force_iface)` is only going to give the length of the interface minus the null-terminator, so we want to make sure that we include that last null-termination byte. 