### PR TITLE
Add usage selection to broker discovery

### DIFF
--- a/client/l2tp_client.c
+++ b/client/l2tp_client.c
@@ -92,6 +92,7 @@ enum l2tp_ctrl_type {
   CONTROL_TYPE_PMTUD_ACK = 0x07,
   CONTROL_TYPE_REL_ACK   = 0x08,
   CONTROL_TYPE_PMTU_NTFY = 0x09,
+  CONTROL_TYPE_USAGE     = 0x0A,
 
   // Reliable messages (0x80 - 0xFF)
   CONTROL_TYPE_LIMIT     = 0x80,
@@ -114,6 +115,7 @@ enum l2tp_limit_type {
 };
 
 enum l2tp_ctrl_state {
+  STATE_GET_USAGE,
   STATE_GET_COOKIE,
   STATE_GET_TUNNEL,
   STATE_KEEPALIVE,
@@ -153,6 +155,8 @@ typedef struct {
   int fd;
   // Tunnel state
   int state;
+  // Usage
+  uint16_t usage;
   // Cookie
   char cookie[8];
   // Netlink socket
@@ -191,6 +195,7 @@ typedef struct {
 
   // Last keepalive and timers
   time_t last_alive;
+  time_t timer_usage;
   time_t timer_cookie;
   time_t timer_tunnel;
   time_t timer_keepalive;
@@ -379,9 +384,11 @@ int context_reinitialize(l2tp_context *ctx)
   if (ctx->broker_resq)
     asyncns_cancel(asyncns_context, ctx->broker_resq);
   ctx->broker_resq = NULL;
+  ctx->usage = -1;
 
   // Reset relevant timers
   time_t now = timer_now();
+  ctx->timer_usage = now;
   ctx->timer_cookie = now;
   ctx->timer_tunnel = now;
   ctx->timer_keepalive = now;
@@ -492,6 +499,19 @@ void context_process_control_packet(l2tp_context *ctx)
 
   // Check packet type
   switch (type) {
+    case CONTROL_TYPE_USAGE: {
+      if (ctx->state == STATE_GET_USAGE) {
+        // broker usage information
+        ctx->usage = parse_u16(&buf);
+        syslog(LOG_DEBUG, "Broker usage: %p %s %u\n", ctx, ctx->broker_hostname, ctx->usage);
+
+        // Mark the connection as being available for later establishment
+        ctx->standby_available = 1;
+        ctx->timer_cookie = timer_now();
+        ctx->state = STATE_GET_COOKIE;
+      }
+      break;
+    }
     case CONTROL_TYPE_COOKIE: {
       if (ctx->state == STATE_GET_COOKIE) {
         if (payload_length != 8)
@@ -947,7 +967,8 @@ void context_process(l2tp_context *ctx)
             syslog(LOG_ERR, "Failed to connect to remote endpoint - check WAN connectivity!");
             ctx->state = STATE_REINIT;
           } else {
-            ctx->state = STATE_GET_COOKIE;
+            ctx->timer_usage = timer_now();
+            ctx->state = STATE_GET_USAGE;
           }
           asyncns_freeaddrinfo(result);
           ctx->broker_resq = NULL;
@@ -961,6 +982,15 @@ void context_process(l2tp_context *ctx)
         ctx->state = STATE_REINIT;
         return;
       }
+      break;
+    }
+    case STATE_GET_USAGE: {
+      // Get usage information if available
+      if (!is_timeout(&ctx->timer_usage, 2))
+        context_send_packet(ctx, CONTROL_TYPE_USAGE, "UUUUUUUU", 8);
+      else
+        // Time out. The broker might not support usage. Ignore it.
+        ctx->state = STATE_GET_COOKIE;
       break;
     }
     case STATE_GET_COOKIE: {
@@ -1101,6 +1131,23 @@ typedef struct {
 } broker_cfg;
 #define MAX_BROKERS 10
 
+int broker_selector_usage(broker_cfg *brokers, int broker_cnt, int ready_cnt)
+{
+   // Select the r'th available broker and use it to establish a tunnel
+   int i = -1;
+   int best = 0;
+   for (i = 0; i < broker_cnt; i++) {
+     if (brokers[i].ctx->standby_available &&
+         (brokers[i].ctx->usage < brokers[best].ctx->usage)) {
+       best = i;
+     }
+   }
+
+   brokers[best].ctx->standby_only = 0;
+   brokers[best].ctx->state = STATE_GET_COOKIE;
+   return best;
+}
+
 int broker_selector_first_available(broker_cfg *brokers, int broker_cnt, int ready_cnt)
 {
   // Select the first available broker and use it to establish a tunnel
@@ -1162,6 +1209,7 @@ void show_help(const char *app)
     "       -s hook       hook script\n"
     "       -t id         local tunnel id (default 1)\n"
     "       -L limit      request broker to set downstream bandwidth limit (in kbps)\n"
+    "       -a            select broker based on use\n"
     "       -g            select first available broker to connect to\n"
     "       -r            select a random broker\n"
   );
@@ -1193,12 +1241,13 @@ int main(int argc, char **argv)
   int broker_cnt = 0;
 
   int c;
-  while ((c = getopt(argc, argv, "hfu:l:b:p:i:s:t:L:I:gr")) != -1) {
+  while ((c = getopt(argc, argv, "hfu:l:b:p:i:s:t:L:I:agr")) != -1) {
     switch (c) {
       case 'h': {
         show_help(argv[0]);
         return 1;
       }
+      case 'a': select_broker = broker_selector_usage; break;
       case 'g': select_broker = broker_selector_first_available; break;
       case 'r': select_broker = broker_selector_random; break;
 

--- a/client/l2tp_client.c
+++ b/client/l2tp_client.c
@@ -1093,6 +1093,43 @@ void context_free(l2tp_context *ctx)
   free(ctx);
 }
 
+// List of brokers
+typedef struct {
+  char *address;
+  char *port;
+  l2tp_context *ctx;
+} broker_cfg;
+#define MAX_BROKERS 10
+
+int broker_selector_first_available(broker_cfg *brokers, int broker_cnt, int ready_cnt)
+{
+  // Select the first available broker and use it to establish a tunnel
+  int i;
+  for (i = 0; i < broker_cnt; i++) {
+    if (brokers[i].ctx->standby_available) {
+      brokers[i].ctx->standby_only = 0;
+      brokers[i].ctx->state = STATE_GET_COOKIE;
+      return i;
+    }
+  }
+  return -1;
+}
+
+int broker_selector_random(broker_cfg *brokers, int broker_cnt, int ready_cnt)
+{
+  // Select the r'th available broker and use it to establish a tunnel
+  int i;
+  int r = rand() % ready_cnt;
+  for (i = 0; i < broker_cnt; i++) {
+    if (brokers[i].ctx->standby_available && (r-- == 0)) {
+      brokers[i].ctx->standby_only = 0;
+      brokers[i].ctx->state = STATE_GET_COOKIE;
+      return i;
+    }
+  }
+  return -1;
+}
+
 void term_handler(int signum)
 {
   (void) signum; /* unused */
@@ -1125,6 +1162,8 @@ void show_help(const char *app)
     "       -s hook       hook script\n"
     "       -t id         local tunnel id (default 1)\n"
     "       -L limit      request broker to set downstream bandwidth limit (in kbps)\n"
+    "       -g            select first available broker to connect to\n"
+    "       -r            select a random broker\n"
   );
 }
 
@@ -1149,24 +1188,20 @@ int main(int argc, char **argv)
   unsigned int tunnel_id = 1;
   int limit_bandwidth_down = 0;
 
-  // List of brokers
-  typedef struct {
-    char *address;
-    char *port;
-    l2tp_context *ctx;
-  } broker_cfg;
-#define MAX_BROKERS 10
-
   broker_cfg brokers[MAX_BROKERS];
+  int (*select_broker)(broker_cfg *, int, int) = broker_selector_first_available;
   int broker_cnt = 0;
 
   int c;
-  while ((c = getopt(argc, argv, "hfu:l:b:p:i:s:t:L:I:")) != -1) {
+  while ((c = getopt(argc, argv, "hfu:l:b:p:i:s:t:L:I:gr")) != -1) {
     switch (c) {
       case 'h': {
         show_help(argv[0]);
         return 1;
       }
+      case 'g': select_broker = broker_selector_first_available; break;
+      case 'r': select_broker = broker_selector_random; break;
+
       case 'f': log_option |= LOG_PERROR; break;
       case 'u': uuid = strdup(optarg); break;
       case 'l': local_ip = strdup(optarg); break;
@@ -1255,8 +1290,9 @@ int main(int argc, char **argv)
     // (whichever is shorter); since all contexts are in standby mode, all
     // available connections will be stuck in GET_COOKIE state
     time_t timer_collect = timer_now();
+    int ready_cnt = 0;
     for (;;) {
-      int ready_cnt = 0;
+      ready_cnt = 0;
       for (i = 0; i < broker_cnt; i++) {
         context_process(brokers[i].ctx);
       }
@@ -1267,24 +1303,20 @@ int main(int argc, char **argv)
 
       if (ready_cnt == broker_cnt || is_timeout(&timer_collect, 20))
         break;
-    }
 
-    // Select the first available broker and use it to establish a tunnel
-    main_context = NULL;
-    for (i = 0; i < broker_cnt; i++) {
-      if (brokers[i].ctx->standby_available) {
-        brokers[i].ctx->standby_only = 0;
-        main_context = brokers[i].ctx;
+      // First available broker just use the first one available 
+      if (select_broker == broker_selector_first_available && ready_cnt > 0)
         break;
-      }
     }
 
-    // If no broker has been selected, restart broker selection
-    if (!main_context) {
-      syslog(LOG_ERR, "No suitable brokers found.");
+    i = select_broker(brokers, broker_cnt, ready_cnt);
+    if (i == -1) {
+      syslog(LOG_ERR, "No suitable brokers found. Retrying in 5 seconds");
+      sleep(5);
       continue;
     }
 
+    main_context = brokers[i].ctx;
     syslog(LOG_INFO, "Selected %s:%s as the best broker.", brokers[i].address,
       brokers[i].port);
 

--- a/tests/jenkins.sh
+++ b/tests/jenkins.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Alexander Couzens <lynxis@fe80.eu>
+# 2015-2016 Alexander Couzens <lynxis@fe80.eu>
 #
 # jenkins script
 
@@ -22,7 +22,8 @@ export CLIENT_REV=$NEW_REV
 export SERVER_REV=$NEW_REV
 nosetests
 
-OLD_REV="c638231efca6b3a6e1c675ac0834a3e851ad1bdc 263eb59098fd11990b6ab75933fb7633055cbc9a 4e4f13cdc630c46909d47441093a5bdaffa0d67f"
+
+OLD_REV="c638231efca6b3a6e1c675ac0834a3e851ad1bdc 4e4f13cdc630c46909d47441093a5bdaffa0d67f"
 # do client NEW_REV against old revs
 for rev in $OLD_REV ; do
   export CLIENT_REV=$NEW_REV

--- a/tests/jenkins.sh
+++ b/tests/jenkins.sh
@@ -36,3 +36,7 @@ for rev in $OLD_REV ; do
   export SERVER_REV=$NEW_REV
   nosetests
 done
+
+for i in seq 1 5; do
+  nosetests test_usage.py
+done

--- a/tests/prepare_server.sh
+++ b/tests/prepare_server.sh
@@ -20,7 +20,7 @@ server.modules = (
         "mod_access",
 	)
 
-server.document-root        = "/testing/test-data"
+server.document-root        = "/"
 server.errorlog             = "/var/log/lighttpd/error.log"
 server.pid-file             = "/var/run/lighttpd.pid"
 server.username             = "www-data"

--- a/tests/prepare_server.sh
+++ b/tests/prepare_server.sh
@@ -47,6 +47,9 @@ cp /srv/tunneldigger/broker/l2tp_broker.cfg.example /srv/tunneldigger/broker/l2t
 sed -i "s/127.0.0.1/$IP/g" /srv/tunneldigger/broker/l2tp_broker.cfg
 sed -i "s/^interface=.*/interface=eth1/g" /srv/tunneldigger/broker/l2tp_broker.cfg
 
+# save the ip into a file where the http server can access it
+echo -n "$IP" > /ip.txt
+
 # WARNING hookpath must be without a leading slash!!!
 HOOKPATH=/testing/hook_server
 sed -i "s!^session.up=.*!session.up=$HOOKPATH/setup_interface.sh!g" /srv/tunneldigger/broker/l2tp_broker.cfg

--- a/tests/run_client.sh
+++ b/tests/run_client.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 
-# local ip
-IP=$(ip -4 -o a s dev eth1  | awk '{ print $4 }' | awk -F/ '{print $1}')
-REMOTEIP=$(ip -4 -o a s dev eth1  | awk '{ print $4 }' | awk -F/ '{print $1}' | awk -F. '{ print $1 "." $2 "." $3 "." 1}')
+SERVERS=""
+for srv in $@ ; do
+	SERVERS=" -b $srv $SERVERS"
+done
 
 cd /srv/tunneldigger/client
-exec /srv/tunneldigger/client/l2tp_client -u foobar -i l2tp0 -t 2 -b $REMOTEIP:8942 -L 102400 -s /testing/hook_client.sh -f
+exec /srv/tunneldigger/client/l2tp_client -u foobar -i l2tp0 -t 2 $SERVERS -L 102400 -s /testing/hook_client.sh -f

--- a/tests/test_nose.py
+++ b/tests/test_nose.py
@@ -44,7 +44,8 @@ class TestTunneldigger(object):
             raise RuntimeError("fail to ping server")
 
     def test_wget_tunneldigger_server(self):
-        ret = CLIENT.attach_wait(lxc.attach_run_command, ["wget", "-t", "2", "-T", "4", "http://192.168.254.1:8080/test_8m", '-O', '/dev/null'])
+        ret = CLIENT.attach_wait(lxc.attach_run_command, [
+            "wget", "-t", "2", "-T", "4", "http://192.168.254.1:8080/testing/test-data/test_8m", '-O', '/dev/null'])
         if ret != 0:
             raise RuntimeError("failed to run the tests")
 

--- a/tests/test_nose.py
+++ b/tests/test_nose.py
@@ -6,7 +6,7 @@ import os
 import signal
 from time import sleep
 import tunneldigger
-from threading import Timer, Thread
+from tunneldigger import run_as_lxc
 
 # random hash
 CONTEXT = None
@@ -20,28 +20,6 @@ SERVER_PID = None
 CLIENT_PID = None
 
 LOG = logging.getLogger("test_nose")
-
-def run_as_lxc(container, command, timeout=10):
-    """
-    run command within container and returns output
-
-    command is a list of command and arguments,
-    The output is limited to the buffersize of pipe (64k on linux)
-    """
-    read_fd, write_fd = os.pipe2(os.O_CLOEXEC | os.O_NONBLOCK)
-    pid = container.attach(lxc.attach_run_command, command, stdout=write_fd, stderr=write_fd)
-    timer = Timer(timeout, os.kill, args=(pid, signal.SIGKILL), kwargs=None)
-    if timeout:
-        timer.start()
-    output_list = []
-    os.waitpid(pid, 0)
-    timer.cancel()
-    try:
-        while True:
-            output_list.append(os.read(read_fd, 1024))
-    except BlockingIOError:
-        pass
-    return bytes().join(output_list)
 
 def setup_module():
     global CONTEXT, SERVER, CLIENT, SERVER_PID, CLIENT_PID

--- a/tests/test_nose.py
+++ b/tests/test_nose.py
@@ -27,7 +27,7 @@ def setup_module():
     LOG.info("using context %s", CONTEXT)
     CLIENT, SERVER = tunneldigger.prepare_containers(CONTEXT, os.environ['CLIENT_REV'], os.environ['SERVER_REV'])
     SERVER_PID = tunneldigger.run_server(SERVER)
-    CLIENT_PID = tunneldigger.run_client(CLIENT)
+    CLIENT_PID = tunneldigger.run_client(CLIENT, ['172.16.16.1:8942'])
     # explicit no Exception when ping fails
     # it's better to poll the client for a ping rather doing a long sleep
     tunneldigger.check_ping(CLIENT, '192.168.254.1', 20)

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+import logging
+import os
+import tunneldigger
+from tunneldigger import check_if_git_contains, run_server, run_client, run_as_lxc
+
+# a revision which supports the usage command
+USAGE_REV = 'c026068c0b57e714ada4f8dbcc5b19bb8c04bb03'
+# a very old revision which does not support usage
+NONUSAGE_REV = '92418563a84f591b55ce4bee9245073b311c30fb'
+
+LOG = logging.getLogger("test_usage")
+
+class TestClientUsage(object):
+    def test_usage(self):
+        """
+        - we need to check if the client version is fresh enought to support usage. otherwise SKIP
+        - setup server A with usage version but one client
+        - setup server B with usage version without any client
+        - setup server C with non-usage version
+
+        - start client conf ABC and check if it's connecting to server B
+        - start client conf AB and check if it's connecting to server B
+        """
+        CONTEXT = []
+        CONTEXT.append(tunneldigger.get_random_context())
+        CONTEXT.append(tunneldigger.get_random_context())
+        CONTEXT.append(tunneldigger.get_random_context())
+
+        bridge_name = "br-%s" % CONTEXT[0]
+        tunneldigger.create_bridge(bridge_name)
+
+        cont_client = tunneldigger.prepare('client', CONTEXT[0] + '_client', os.environ['CLIENT_REV'], bridge_name, '172.16.16.2/24')
+
+        if not check_if_git_contains(cont_client, '/git_repo', os.environ['CLIENT_REV'], '657aa1c81c6e487749d5777bbea6681e478a8a01'):
+            try:
+                from nose import SkipTest
+            except ImportError:
+                LOG.error("Can not skip test, returning without any Exception!")
+                return
+            raise SkipTest("Client too old for this test.")
+
+        servers = ['172.16.16.100', '172.16.16.101', '172.16.16.102']
+        cont_first = tunneldigger.prepare('server', CONTEXT[0] + '_server', USAGE_REV, bridge_name, servers[0]+'/24')
+        cont_second = tunneldigger.prepare('server', CONTEXT[1] + '_server', USAGE_REV, bridge_name, servers[1]+'/24')
+        cont_nonusage = tunneldigger.prepare('server', CONTEXT[2] + '_server', NONUSAGE_REV, bridge_name, servers[2]+'/24')
+        cont_all_servers = [cont_first, cont_second, cont_nonusage]
+
+        cont_dummy_client = tunneldigger.prepare('client', CONTEXT[1] + '_client', os.environ['CLIENT_REV'],
+                                                 bridge_name, '172.16.16.1/24')
+        cont_all_clients = [cont_dummy_client, cont_client]
+
+        # start all servers
+        pids_all_servers = [run_server(x) for x in cont_all_servers]
+        pid_dummy_client = run_client(cont_dummy_client, [servers[0]+':8942'])
+
+        LOG.info("Created servers %s", [x.name for x in cont_all_servers])
+        LOG.info("Created clients %s", [x.name for x in cont_all_clients])
+
+        # check if the dummy client is connected to server A
+        if not tunneldigger.check_ping(cont_dummy_client, '192.168.254.1', 10):
+            raise RuntimeError("Dummy Client failed to ping server")
+
+        pid_client = run_client(cont_client, [x + ':8942' for x in servers])
+
+        # check if the client is connected to some server
+        if not tunneldigger.check_ping(cont_client, '192.168.254.1', 10):
+            raise RuntimeError("Test client failed to ping server")
+
+        # now everything is connect. let's see if it's connecting to server B
+        address = run_as_lxc(cont_client, ['curl', '--silent', 'http://192.168.254.1:8080/ip.txt'])
+        if address != bytes(servers[1], 'utf-8'):
+            raise RuntimeError('Client is connected to "%s" but should be "%s"' % (address, bytes(servers[1], 'utf-8')))
+

--- a/tests/tunneldigger.py
+++ b/tests/tunneldigger.py
@@ -70,23 +70,17 @@ def get_random_context():
     context = hex(context)[2:]
     return context
 
-def configure_network(container, bridge, is_server):
-    """ configure the container and connect them to the bridge 
+def configure_network(container, bridge, ip_netmask):
+    """ configure the container and connect them to the bridge
     container is a lxc container
-    context is the hex for the bridge """
+    bridge the name of your bridge to attach the container
+    ip_netmask is the give address in cidr. e.g. 192.168.1.2/24"""
     config = [
         ('lxc.network.type', 'veth'),
         ('lxc.network.link', bridge),
         ('lxc.network.flags', 'up'),
+        ('lxc.network.ipv4', ip_netmask),
         ]
-    if is_server:
-        config.append(
-            ('lxc.network.ipv4', '172.16.16.1/24'),
-            )
-    else:
-        config.append(
-            ('lxc.network.ipv4', '172.16.16.2/24'),
-            )
 
     for item in config:
         container.append_config_item(item[0], item[1])

--- a/tests/tunneldigger.py
+++ b/tests/tunneldigger.py
@@ -293,6 +293,20 @@ def run_as_lxc(container, command, timeout=10):
         pass
     return bytes().join(output_list)
 
+def check_if_git_contains(container, repo_path, top_commit, search_for_commit):
+    """ checks if a git commit is included within a certain tree
+    look into repo under *repo_path*, check if search_for_commit is included in the top_commit
+    """
+    cmd = ['sh', '-c', 'cd %s ; git merge-base "%s" "%s"' % (repo_path, top_commit, search_for_commit)]
+    base = run_as_lxc(container, cmd)
+    sys.stderr.write("\nGIT call is %s\n" % cmd)
+    sys.stderr.write("\nGIT returns is %s\n" % base)
+    if base.startswith(bytes(search_for_commit, 'utf-8')):
+        # the base must be the search_for_commit when search_for_commit should included into top_commit
+        # TODO: replace with git merge-base --is-ancestor
+        return True
+    return False
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Test Tunneldigger version against each other")
     # operation on the hosts

--- a/tests/tunneldigger.py
+++ b/tests/tunneldigger.py
@@ -225,7 +225,8 @@ def run_client(client, servers=[]):
 
 def run_tests(server, client):
     """ the client should be already connect to the server """
-    ret = client.attach_wait(lxc.attach_run_command, ["wget", "-t", "2", "-T", "4", "http://192.168.254.1:8080/test_8m", '-O', '/dev/null'])
+    ret = client.attach_wait(lxc.attach_run_command, [
+        "wget", "-t", "2", "-T", "4", "http://192.168.254.1:8080/testing/test-data/test_8m", '-O', '/dev/null'])
     if ret != 0:
         raise RuntimeError("failed to run the tests")
 

--- a/tests/tunneldigger.py
+++ b/tests/tunneldigger.py
@@ -137,7 +137,7 @@ def testing(client_rev, server_rev):
     print("generate a run for %s" % context)
     client, server = prepare_containers(context, client_rev, server_rev)
     spid = run_server(server)
-    cpid = run_client(client)
+    cpid = run_client(client, ['172.16.16.1:8942'])
 
     # wait until client is connected to server
     if not check_ping(client, '192.168.254.1', 20):
@@ -212,11 +212,15 @@ def run_server(server):
     spid = server.attach(lxc.attach_run_command, ['/testing/run_server.sh'])
     return spid
 
-def run_client(client):
+def run_client(client, servers=[]):
     """ run_client(client)
     client is a container
+    servers is a list of all available servers
     """
-    cpid = client.attach(lxc.attach_run_command, ['/testing/run_client.sh'])
+
+    arguments = ['/testing/run_client.sh']
+    arguments.extend(servers)
+    cpid = client.attach(lxc.attach_run_command, arguments)
     return cpid
 
 def run_tests(server, client):


### PR DESCRIPTION
This is an RFC.

It's based on commits from Christian Mehlis.
* implement broker selection in a generic way
* Client ask for an usage and select the broker with the smallest value.

It's a way to implement load balancing over multiple hosts. The broker use the max tunnel configuration to calculate it's usage. The usage itself is a 1 Byte metric sent to the client.
The client decide then to whom it will connect.

Before I go refactoring this, my question is:
Do we want this feature (not this exact code) to be upstream?
Is the usage a optional feature? Configurable? Or do we want all new servers supporting this, but still be compatible to old clients?

* **This needs testing**
* **This needs refactoring into smaller commits**
* **This pullrequest break the client**