### PR TITLE
client: change variable type to int for the return value of getopt()

### DIFF
--- a/client/l2tp_client.c
+++ b/client/l2tp_client.c
@@ -1134,8 +1134,8 @@ int main(int argc, char **argv)
   broker_cfg brokers[MAX_BROKERS];
   int broker_cnt = 0;
 
-  char c;
-  while ((c = getopt(argc, argv, "hfu:l:b:p:i:s:t:L:I:")) != EOF) {
+  int c;
+  while ((c = getopt(argc, argv, "hfu:l:b:p:i:s:t:L:I:")) != -1) {
     switch (c) {
       case 'h': {
         show_help(argv[0]);


### PR DESCRIPTION
On some platforms (e.g. ppc) this check will otherwise fail,
because the cast priority is different.