### PR TITLE
Adding fq_codel tc rule to help alleviate buffer bloat.

### DIFF
--- a/broker/traffic_control.py
+++ b/broker/traffic_control.py
@@ -41,3 +41,6 @@ class TrafficControl(object):
         self.tc('class add dev %s parent 1: classid 1:1 htb rate %dkbit ceil %dkbit' % (
             self.interface, bandwidth, bandwidth
         ))
+        self.tc('tc qdisc add dev %s parent 1:1 fq_codel' % (
+            self.interface
+        ), True)


### PR DESCRIPTION
We talked with Dave Taht of "Make Wifi Fast" and he suggested that using fq_codel in this manner could help alleviate any potential buffer bloat with the hard cap ceiling in tc.

fq_codel should be included in linux kernel 3.6 and above so I don't think there's any dependency issue. Does it make sense to include a check that it exists? Or a config to turn it on/off?