### PR TITLE
README.rst: replace open ticket link with a more specific link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ code is available on GitHub_. If you have any questions or if you want to
 discuss the project, use `development mailing list`_.
 
 .. _development Trac: https://dev.wlan-si.net/wiki/Tunneldigger
-.. _existing open tickets: https://dev.wlan-si.net/report
+.. _existing open tickets: https://dev.wlan-si.net/report/15
 .. _open a new one: https://dev.wlan-si.net/newticket
 .. _GitHub: https://github.com/wlanslovenija/tunneldigger
 .. _development mailing list: https://wlan-si.net/lists/info/development


### PR DESCRIPTION
The new link points to the 'tunneldigger' report