### PR TITLE
Fixing double `tc`  command bug in traffic control code.

### DIFF
--- a/broker/traffic_control.py
+++ b/broker/traffic_control.py
@@ -41,6 +41,6 @@ class TrafficControl(object):
         self.tc('class add dev %s parent 1: classid 1:1 htb rate %dkbit ceil %dkbit' % (
             self.interface, bandwidth, bandwidth
         ))
-        self.tc('tc qdisc add dev %s parent 1:1 fq_codel' % (
+        self.tc('qdisc add dev %s parent 1:1 fq_codel' % (
             self.interface
         ), True)


### PR DESCRIPTION
I'm pretty sure this is my fault from when I added the fq_codel code. Sorry about that...