### PR TITLE
client: remove #define HAVE_* and config.h

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ dist: trusty
 install:
   - sudo add-apt-repository universe
   - sudo apt-get -qq update
-  - sudo apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -qq --assume-no install bison build-essential flex gawk gettext git git-core libncurses5-dev libssl-dev lxc m4 subversion unzip zlib1g-dev python3-lxc python3-nose
+  - sudo apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -qq --assume-no install bison build-essential flex gawk gettext git git-core libncurses5-dev libssl-dev lxc m4 subversion unzip zlib1g-dev python3-lxc python3-nose linux-libc-dev libnl-dev
   - sudo modprobe l2tp_netlink
   - sudo modprobe l2tp_ip
   - sudo modprobe l2tp_eth

--- a/client/asyncns.c
+++ b/client/asyncns.c
@@ -182,27 +182,6 @@ typedef union packet {
     res_response_t res_response;
 } packet_t;
 
-#ifndef HAVE_STRNDUP
-
-static char *strndup(const char *s, size_t l) {
-    size_t a;
-    char *n;
-
-    a = strlen(s);
-    if (a > l)
-        a = l;
-
-    if (!(n = malloc(a+1)))
-        return NULL;
-
-    memcpy(n, s, a);
-    n[a] = 0;
-
-    return n;
-}
-
-#endif
-
 #ifndef HAVE_PTHREAD
 
 static int close_allv(const int except_fds[]) {

--- a/client/asyncns.c
+++ b/client/asyncns.c
@@ -18,15 +18,6 @@
   <http://www.gnu.org/licenses/>.
 ***/
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
-#define HAVE_STRNDUP 1
-#define HAVE_PTHREAD 1
-#define HAVE_SYS_PRCTL_H 1
-#define HAVE_SETRESUID 1
-
 #include <assert.h>
 #include <fcntl.h>
 #include <signal.h>

--- a/tests/jenkins.sh
+++ b/tests/jenkins.sh
@@ -9,6 +9,11 @@ nosetests() {
 
 set -e
 
+# compile test the l2tp client
+echo "Try to compile the l2tp client"
+cd $WORKSPACE/client/
+make
+
 # prepare lxc container template
 $WORKSPACE/tests/tunneldigger.py --setup
 


### PR DESCRIPTION
HAVE_* should set by a configure/cmake, not by the source.
config.h usually contains those variables.
This fixes build errors with openwrt trunk, because warnings treated as
Errors.