### PR TITLE
Fix checking for netlink errors when receiving only a single message

### DIFF
--- a/broker/src/tunneldigger_broker/netlink.py
+++ b/broker/src/tunneldigger_broker/netlink.py
@@ -153,6 +153,17 @@ class Connection:
         self.descriptor.send(msg)
 
     def recv(self, multiple = False):
+        """
+        Receive message(s) from the netlink socket.
+
+        :param multiple: Control the receiving mode.
+
+        In single-message mode, exactly one message is received.  If that message is an error,
+        an exception is raised.  Otherwise (including if the message is an ack), it is returned.
+        In multiple-message mode, messages are received until the first NLMSG_DONE.
+        If there is an error, an exception is raised.  Acks and the final NLMSG_DONE are dropped.
+        The other messages are returned in a list.
+        """
         messages = []
         done = False
 

--- a/broker/src/tunneldigger_broker/netlink.py
+++ b/broker/src/tunneldigger_broker/netlink.py
@@ -165,6 +165,14 @@ class Connection:
                 msg.pid = pid
                 contents = contents[msglen:]
 
+                if msg.type == NLMSG_ERROR:
+                    errno = -struct.unpack("i", msg.payload[:4])[0]
+                    if errno != 0:
+                        err = OSError("Netlink error: %s (%d)" % (
+                                                             os.strerror(errno), errno))
+                        err.errno = errno
+                        raise err
+                # A non-error message
                 if not multiple:
                     messages.append(msg)
                     done = True
@@ -173,12 +181,8 @@ class Connection:
                     done = True
                     break
                 elif msg.type == NLMSG_ERROR:
-                    errno = -struct.unpack("i", msg.payload[:4])[0]
-                    if errno != 0:
-                        err = OSError("Netlink error: %s (%d)" % (
-                                                             os.strerror(errno), errno))
-                        err.errno = errno
-                        raise err
+                    # an ack
+                    pass
                 else:
                     messages.append(msg)
 

--- a/broker/src/tunneldigger_broker/netlink.py
+++ b/broker/src/tunneldigger_broker/netlink.py
@@ -172,6 +172,7 @@ class Connection:
                                                              os.strerror(errno), errno))
                         err.errno = errno
                         raise err
+
                 # A non-error message
                 if not multiple:
                     messages.append(msg)


### PR DESCRIPTION
The current implementation fails to raise an exception when an error is returned.

This masks a problem where on newer kernels, tunneldigger fails to create tunnels because l2tpv3 session IDs have to be globally unique.