### PR TITLE
Implement some missing config options

### DIFF
--- a/broker/l2tp_broker.cfg.example
+++ b/broker/l2tp_broker.cfg.example
@@ -15,6 +15,8 @@ tunnel_id_base=100
 ; configure disjunct ports, and tunnel identifiers in order for
 ; namespacing to work
 namespace=default
+; Reject connections if there are less than N seconds since the last connection
+connection_rate_limit=10
 
 [log]
 ; Verbosity

--- a/broker/l2tp_broker.cfg.example
+++ b/broker/l2tp_broker.cfg.example
@@ -15,12 +15,8 @@ tunnel_id_base=100
 ; configure disjunct ports, and tunnel identifiers in order for
 ; namespacing to work
 namespace=default
-; check if all kernel module are loaded. Do not check for built-ins.
-check_modules=true
 
 [log]
-; Log filename
-filename=tunneldigger-broker.log
 ; Verbosity
 verbosity=DEBUG
 ; Should IP addresses be logged or not

--- a/broker/src/tunneldigger_broker/broker.py
+++ b/broker/src/tunneldigger_broker/broker.py
@@ -54,6 +54,7 @@ class TunnelManager(object):
         # Rate limit creation of new tunnels to at most one every 10 seconds to prevent the
         # broker from being overwhelmed with creating tunnels, especially on embedded devices.
         if self.last_tunnel_created is not None and now - self.last_tunnel_created < 10:
+            logger.info("Rejecting tunnel %s:%s (%s) due to rate limiting" % (address[0], address[1], uuid))
             return False
 
         try:

--- a/broker/src/tunneldigger_broker/broker.py
+++ b/broker/src/tunneldigger_broker/broker.py
@@ -18,7 +18,7 @@ class TunnelManager(object):
     Tunnel manager.
     """
 
-    def __init__(self, hook_manager, max_tunnels, tunnel_id_base, tunnel_port_base, namespace, log_ip_addresses):
+    def __init__(self, hook_manager, max_tunnels, tunnel_id_base, tunnel_port_base, namespace, connection_rate_limit, log_ip_addresses):
         """
         Constructs a tunnel manager.
 
@@ -37,6 +37,7 @@ class TunnelManager(object):
         self.namespace = namespace
         self.tunnels = {}
         self.last_tunnel_created = None
+        self.connection_rate_limit = connection_rate_limit
         self.log_ip_addresses = log_ip_addresses
 
     def create_tunnel(self, broker, address, uuid, remote_tunnel_id):
@@ -59,7 +60,7 @@ class TunnelManager(object):
 
         # Rate limit creation of new tunnels to at most one every 10 seconds to prevent the
         # broker from being overwhelmed with creating tunnels, especially on embedded devices.
-        if self.last_tunnel_created is not None and now - self.last_tunnel_created < 10:
+        if self.last_tunnel_created is not None and now - self.last_tunnel_created < self.connection_rate_limit:
             logger.info("Rejecting tunnel %s due to rate limiting" % tunnel_str)
             return False
 

--- a/broker/src/tunneldigger_broker/hooks.py
+++ b/broker/src/tunneldigger_broker/hooks.py
@@ -96,7 +96,7 @@ class HookManager(object):
     Manages hooks.
     """
 
-    def __init__(self, event_loop):
+    def __init__(self, event_loop, log_arguments):
         """
         Constructs a new hook manager instance.
 
@@ -106,6 +106,7 @@ class HookManager(object):
         self.event_loop = event_loop
         self.hooks = {}
         self.processes = {}
+        self.log_arguments = log_arguments
 
         # Create a file descriptor so we can get notified of SIGCHLD signals in the
         # context of the event loop (and not in an arbitrary location).
@@ -141,7 +142,10 @@ class HookManager(object):
         if not script:
             return
 
-        logger.info("Running hook '%s' via script '%s %s'." % (name, script, " ".join([str(x) for x in args])))
+        if self.log_arguments:
+            logger.info("Running hook '%s' via script '%s %s'." % (name, script, " ".join([str(x) for x in args])))
+        else:
+            logger.info("Running hook '%s' via script '%s'." % (name, script))
         try:
             process = HookProcess(name, script, args)
             process.register(self.event_loop)

--- a/broker/src/tunneldigger_broker/hooks.py
+++ b/broker/src/tunneldigger_broker/hooks.py
@@ -146,6 +146,7 @@ class HookManager(object):
             logger.info("Running hook '%s' via script '%s %s'." % (name, script, " ".join([str(x) for x in args])))
         else:
             logger.info("Running hook '%s' via script '%s'." % (name, script))
+
         try:
             process = HookProcess(name, script, args)
             process.register(self.event_loop)

--- a/broker/src/tunneldigger_broker/main.py
+++ b/broker/src/tunneldigger_broker/main.py
@@ -41,7 +41,7 @@ LOGGING_CONFIGURATION = {
     'loggers': {
         'tunneldigger': {
             'handlers': ['console'],
-            'level': 'INFO',
+            'level': config.get('log', 'verbosity'),
         }
     }
 }

--- a/broker/src/tunneldigger_broker/main.py
+++ b/broker/src/tunneldigger_broker/main.py
@@ -55,7 +55,7 @@ logger.info("Initializing the tunneldigger broker.")
 event_loop = eventloop.EventLoop()
 
 # Initialize the hook manager.
-hook_manager = hooks.HookManager(event_loop)
+hook_manager = hooks.HookManager(event_loop, log_arguments=config.getboolean('log', 'log_ip_addresses'))
 for hook in ('session.up', 'session.pre-down', 'session.down', 'session.mtu-changed'):
     try:
         script = config.get('hooks', hook).strip()
@@ -74,6 +74,7 @@ tunnel_manager = broker.TunnelManager(
     tunnel_id_base=config.getint('broker', 'tunnel_id_base'),
     tunnel_port_base=config.getint('broker', 'port_base'),
     namespace=config.get('broker', 'namespace'),
+    log_ip_addresses=config.getboolean('log', 'log_ip_addresses'),
 )
 tunnel_manager.initialize()
 

--- a/broker/src/tunneldigger_broker/main.py
+++ b/broker/src/tunneldigger_broker/main.py
@@ -74,6 +74,7 @@ tunnel_manager = broker.TunnelManager(
     tunnel_id_base=config.getint('broker', 'tunnel_id_base'),
     tunnel_port_base=config.getint('broker', 'port_base'),
     namespace=config.get('broker', 'namespace'),
+    connection_rate_limit=config.getint('broker', 'connection_rate_limit'),
     log_ip_addresses=config.getboolean('log', 'log_ip_addresses'),
 )
 tunnel_manager.initialize()

--- a/broker/src/tunneldigger_broker/main.py
+++ b/broker/src/tunneldigger_broker/main.py
@@ -55,7 +55,10 @@ logger.info("Initializing the tunneldigger broker.")
 event_loop = eventloop.EventLoop()
 
 # Initialize the hook manager.
-hook_manager = hooks.HookManager(event_loop, log_arguments=config.getboolean('log', 'log_ip_addresses'))
+hook_manager = hooks.HookManager(
+    event_loop=event_loop,
+    log_arguments=config.getboolean('log', 'log_ip_addresses'),
+)
 for hook in ('session.up', 'session.pre-down', 'session.down', 'session.mtu-changed'):
     try:
         script = config.get('hooks', hook).strip()

--- a/broker/src/tunneldigger_broker/protocol.py
+++ b/broker/src/tunneldigger_broker/protocol.py
@@ -127,7 +127,7 @@ class HandshakeProtocolMixin(object):
                 remote_tunnel_id = 1
 
             if not self.create_tunnel(address, uuid, remote_tunnel_id):
-                logger.warning("Failed to create tunnel while processing prepare request.")
+                logger.warning("Failed to create tunnel (%s) while processing prepare request." % uuid)
                 self.write_message(address, CONTROL_TYPE_ERROR)
 
             return True


### PR DESCRIPTION
There is a significant discrepancy between the config options listed in l2tp_broker.cfg.example and the ones actually supported.  This PR fixes that by, mostly, implementing `log.verbosity` and `log.log_ip_addresses`. Furthermore, it makes the hard-coded limit of one connection per 10s configurable.