### PR TITLE
Fix computing the set of available tunnel_ids

### DIFF
--- a/broker/src/tunneldigger_broker/broker.py
+++ b/broker/src/tunneldigger_broker/broker.py
@@ -32,7 +32,7 @@ class TunnelManager(object):
         self.hook_manager = hook_manager
         self.max_tunnels = max_tunnels
         self.tunnel_id_base = tunnel_id_base
-        self.tunnel_ids = set(xrange(tunnel_id_base, tunnel_id_base + max_tunnels + 1))
+        self.tunnel_ids = set(xrange(tunnel_id_base, tunnel_id_base + max_tunnels))
         self.tunnel_port_base = tunnel_port_base
         self.namespace = namespace
         self.tunnels = {}


### PR DESCRIPTION
With a tunnel_id_base of 100 and max_tunnels 100, the valid tunnel_ids range from 100 inclusive to 200 exclusive. So we want to call `xrange(100, 200)`. No need to add `1` more, that will actually add 101 tunnel IDs.

Patch by @rohammer