### PR TITLE
close hook process file descriptors

### DIFF
--- a/broker/src/tunneldigger_broker/hooks.py
+++ b/broker/src/tunneldigger_broker/hooks.py
@@ -72,6 +72,8 @@ class HookProcess(object):
             pass
 
         self.process.poll()
+        self.process.stdout.close()
+        self.process.stderr.close()
 
     def read(self, file_object):
         """


### PR DESCRIPTION
This helps with #55. Now I am no longer seeing hundreds of open pipe file descriptors.

There are still many many timerfd though, so I am wondering if there is another leak.