### PR TITLE
Avoid reconnecting to a broker that failed on us

### DIFF
--- a/client/l2tp_client.c
+++ b/client/l2tp_client.c
@@ -229,12 +229,12 @@ static asyncns_t *asyncns_context = NULL;
 
 int broker_selector_usage(broker_cfg *brokers, int broker_cnt, int ready_cnt)
 {
-   // Select the r'th available broker and use it to establish a tunnel.
+   // Select the available broker with the least usage and use it to establish a tunnel.
    int i = -1;
-   int best = 0;
+   int best = -1;
    for (i = 0; i < broker_cnt; i++) {
      if (brokers[i].ctx->standby_available &&
-         (brokers[i].ctx->usage < brokers[best].ctx->usage)) {
+         (best < 0 || brokers[i].ctx->usage < brokers[best].ctx->usage)) {
        best = i;
      }
    }

--- a/client/l2tp_client.c
+++ b/client/l2tp_client.c
@@ -553,7 +553,7 @@ void context_process_control_packet(l2tp_context *ctx)
       if (ctx->state == STATE_USAGE_WAIT) {
         // Broker usage information.
         ctx->usage = parse_u16(&buf);
-        syslog(LOG_DEBUG, "Broker usage: %p %s %u\n", ctx, ctx->broker_hostname, ctx->usage);
+        syslog(LOG_DEBUG, "Broker usage of %s:%s: %u\n", ctx->broker_hostname, ctx->broker_port, ctx->usage);
 
         // Mark the connection as being available for later establishment.
         ctx->standby_available = 1;


### PR DESCRIPTION
Currently, `broker_selector_usage` returns `0` when no broker is ready. That's just wrong, a selector should never return a broker that is not ready. It should return `-1` instead, like the others, which will make broker selection restart.

EDIT: I expanded the scope of the PR; see below.