### PR TITLE
Unique session ids

### DIFF
--- a/broker/src/tunneldigger_broker/broker.py
+++ b/broker/src/tunneldigger_broker/broker.py
@@ -58,7 +58,7 @@ class TunnelManager(object):
 
         :param client_features: Client feature flags
         """
-        return int((float(len(self.tunnels)) / self.max_tunnels) * 65535)
+        return int((float(len(self.tunnels)) / self.max_tunnels) * 0xFFFF)
 
     def create_tunnel(self, broker, address, uuid, remote_tunnel_id, client_features):
         """

--- a/broker/src/tunneldigger_broker/limits.py
+++ b/broker/src/tunneldigger_broker/limits.py
@@ -12,16 +12,14 @@ class LimitManager(object):
     Tunnel traffic limit manager.
     """
 
-    def __init__(self, tunnel, session_id):
+    def __init__(self, tunnel):
         """
         Class constructor.
 
         :param tunnel: Tunnel instance
-        :parma session_id: Session identifier
         """
 
         self.tunnel = tunnel
-        self.session_id = session_id
 
     def configure(self, limit_message):
         """
@@ -48,7 +46,7 @@ class LimitManager(object):
 
             # Setup bandwidth limit using Linux traffic shaping.
             try:
-                tc = traffic_control.TrafficControl(self.tunnel.get_session_name(self.session_id))
+                tc = traffic_control.TrafficControl(self.tunnel.get_session_name())
                 tc.reset()
                 tc.set_fixed_bandwidth(bandwidth)
             except traffic_control.TrafficControlError:

--- a/broker/src/tunneldigger_broker/protocol.py
+++ b/broker/src/tunneldigger_broker/protocol.py
@@ -37,6 +37,10 @@ ERROR_REASON_TIMEOUT        = 0x03
 ERROR_REASON_FAILURE        = 0x04 # e.q. on malloc() failure
 ERROR_REASON_UNDEFINED      = 0x05
 
+# Session feature flags
+FEATURE_UNIQUE_SESSION_ID = 1 << 0
+FEATURES_MASK = FEATURE_UNIQUE_SESSION_ID
+
 # Limit types.
 LIMIT_TYPE_BANDWIDTH_DOWN = 0x01
 
@@ -123,14 +127,14 @@ class HandshakeProtocolMixin(object):
             offset = 0
 
             # Verify cookie value.
-            timestamp = msg_data[offset:offset+2]
+            timestamp = msg_data[offset:offset + 2]
             offset += 2
             signed_value = '%s%s%s' % (address[0], address[1], timestamp)
             signature = hmac.HMAC(SECRET_KEY, signed_value, hashlib.sha1).digest()[:6]
             timestamp = struct.unpack('!H', timestamp)[0]
 
             # Reject message if more than 2 protocol ticks old.  One tick is 1 >> 6 = 64 seconds.
-            if signature != msg_data[offset:offset+6] or abs(protocol_time() - timestamp) > 2:
+            if signature != msg_data[offset:offset + 6] or abs(protocol_time() - timestamp) > 2:
                 return
             offset += 6
 
@@ -164,7 +168,7 @@ class HandshakeProtocolMixin(object):
 
             client_features = 0
             try:
-                client_features = struct.unpack('!I', msg_data[8:8+4])[0]
+                client_features = struct.unpack('!I', msg_data[8:8 + 4])[0]
             except (struct.error, IndexError):
                 pass
 

--- a/broker/src/tunneldigger_broker/tunnel.py
+++ b/broker/src/tunneldigger_broker/tunnel.py
@@ -39,6 +39,10 @@ PMTU_PROBE_SIZE_COUNT = len(PMTU_PROBE_SIZES)
 PMTU_PROBE_REPEATS = 4
 PMTU_PROBE_COMBINATIONS = PMTU_PROBE_SIZE_COUNT * PMTU_PROBE_REPEATS
 
+# Session feature flags
+FEATURE_UNIQUE_SESSION_ID = 1 << 0
+FEATURES_MASK = FEATURE_UNIQUE_SESSION_ID
+
 # Logger.
 logger = logging.getLogger("tunneldigger.tunnel")
 
@@ -52,7 +56,7 @@ class Tunnel(protocol.HandshakeProtocolMixin, network.Pollable):
     A tunnel descriptor.
     """
 
-    def __init__(self, broker, address, endpoint, uuid, tunnel_id, remote_tunnel_id, pmtu_fixed):
+    def __init__(self, broker, address, endpoint, uuid, tunnel_id, remote_tunnel_id, pmtu_fixed, client_features):
         """
         Construct a tunnel.
 
@@ -71,8 +75,12 @@ class Tunnel(protocol.HandshakeProtocolMixin, network.Pollable):
         self.broker = broker
         self.endpoint = endpoint
         self.uuid = uuid
+        self.client_features = client_features
         self.tunnel_id = tunnel_id
         self.remote_tunnel_id = remote_tunnel_id
+        self.session_id = self.tunnel_id if self.client_features & FEATURE_UNIQUE_SESSION_ID else 1
+        self.remote_session_id = self.remote_tunnel_id if self.client_features & FEATURE_UNIQUE_SESSION_ID else 1
+
         self.last_alive = time.time()
         self.created_time = None
         self.keepalive_seqno = 0
@@ -93,14 +101,12 @@ class Tunnel(protocol.HandshakeProtocolMixin, network.Pollable):
 
         return self.broker.tunnel_manager
 
-    def get_session_name(self, session_id):
+    def get_session_name(self):
         """
         Returns the interface name for a tunnel's session.
-
-        :param session_id: Session identifier
         """
 
-        return "l2tp%d%d" % (self.tunnel_id, session_id)
+        return "l2tp%d-%d" % (self.tunnel_id, self.session_id)
 
     def setup_tunnel(self):
         """
@@ -112,7 +118,7 @@ class Tunnel(protocol.HandshakeProtocolMixin, network.Pollable):
             self.broker.netlink.tunnel_create(self.tunnel_id, self.remote_tunnel_id, self.socket.fileno())
 
             # Create a pseudowire L2TP session over the tunnel.
-            self.broker.netlink.session_create(self.tunnel_id, 1, 1, self.get_session_name(1))
+            self.broker.netlink.session_create(self.tunnel_id, self.session_id, self.remote_session_id, self.get_session_name())
         except l2tp.L2TPTunnelExists:
             self.socket.close()
             raise
@@ -174,7 +180,14 @@ class Tunnel(protocol.HandshakeProtocolMixin, network.Pollable):
         self.created_time = time.time()
 
         # Respond with tunnel establishment message.
-        self.write_message(self.endpoint, protocol.CONTROL_TYPE_TUNNEL, struct.pack('!I', self.tunnel_id))
+        server_features = self.client_features & FEATURES_MASK
+        if server_features:
+            # Tell the client which features we support.
+            msg = struct.pack('!II', self.tunnel_id, server_features)
+        else:
+            # There are no features to speak of.
+            msg = struct.pack('!I', self.tunnel_id)
+        self.write_message(self.endpoint, protocol.CONTROL_TYPE_TUNNEL, msg)
 
         # Spawn keepalive timer.
         self.create_timer(self.keepalive, timeout=random.randrange(3, 15), interval=5)
@@ -190,8 +203,8 @@ class Tunnel(protocol.HandshakeProtocolMixin, network.Pollable):
         self.broker.hook_manager.run_hook(
             'session.up',
             self.tunnel_id,
-            1,
-            self.get_session_name(1),
+            self.session_id,
+            self.get_session_name(),
             self.tunnel_mtu,
             self.endpoint[0],
             self.endpoint[1],
@@ -240,21 +253,21 @@ class Tunnel(protocol.HandshakeProtocolMixin, network.Pollable):
 
         # Alter tunnel MTU.
         try:
-            interface_name = (self.get_session_name(1) + '\x00' * 16)[:16]
+            interface_name = (self.get_session_name() + '\x00' * 16)[:16]
             data = struct.pack("16si", interface_name, self.tunnel_mtu)
             fcntl.ioctl(self.socket, SIOCSIFMTU, data)
         except IOError:
             logger.warning("Failed to set MTU for tunnel %d! Is the interface down?" % self.tunnel_id)
 
-        self.broker.netlink.session_modify(self.tunnel_id, 1, self.tunnel_mtu)
+        self.broker.netlink.session_modify(self.tunnel_id, self.session_id, self.tunnel_mtu)
 
         if not initial:
             # Run MTU changed hook.
             self.broker.hook_manager.run_hook(
                 'session.mtu-changed',
                 self.tunnel_id,
-                1,
-                self.get_session_name(1),
+                self.session_id,
+                self.get_session_name(),
                 old_tunnel_mtu,
                 self.tunnel_mtu,
                 self.uuid,
@@ -287,8 +300,8 @@ class Tunnel(protocol.HandshakeProtocolMixin, network.Pollable):
         self.broker.hook_manager.run_hook(
             'session.pre-down',
             self.tunnel_id,
-            1,
-            self.get_session_name(1),
+            self.session_id,
+            self.get_session_name(),
             self.tunnel_mtu,
             self.endpoint[0],
             self.endpoint[1],
@@ -296,14 +309,14 @@ class Tunnel(protocol.HandshakeProtocolMixin, network.Pollable):
             self.uuid,
         )
 
-        self.broker.netlink.session_delete(self.tunnel_id, 1)
+        self.broker.netlink.session_delete(self.tunnel_id, self.session_id)
 
         # Run down hook.
         self.broker.hook_manager.run_hook(
             'session.down',
             self.tunnel_id,
-            1,
-            self.get_session_name(1),
+            self.session_id,
+            self.get_session_name(),
             self.tunnel_mtu,
             self.endpoint[0],
             self.endpoint[1],
@@ -327,7 +340,7 @@ class Tunnel(protocol.HandshakeProtocolMixin, network.Pollable):
 
         self.broker.tunnel_manager.destroy_tunnel(self)
 
-    def create_tunnel(self, address, uuid, remote_tunnel_id):
+    def create_tunnel(self, address, uuid, remote_tunnel_id, client_features):
         """
         The tunnel may receive a valid create tunnel message in case our previous
         response has been lost. In this case, we just need to reply with an identical
@@ -344,6 +357,10 @@ class Tunnel(protocol.HandshakeProtocolMixin, network.Pollable):
 
         if remote_tunnel_id != self.remote_tunnel_id:
             logger.warning("Protocol error: tunnel identifier has changed.")
+            return False
+
+        if client_features != self.client_features:
+            logger.warning("Protocol error: client features have changed.")
             return False
 
         # Respond with tunnel establishment message.
@@ -406,7 +423,7 @@ class Tunnel(protocol.HandshakeProtocolMixin, network.Pollable):
 
             if msg_type == protocol.CONTROL_TYPE_LIMIT:
                 # Client requests limit configuration.
-                limit_manager = limits.LimitManager(self, 1)
+                limit_manager = limits.LimitManager(self)
                 limit_manager.configure(msg_data[2:])
                 return True
 

--- a/broker/src/tunneldigger_broker/tunnel.py
+++ b/broker/src/tunneldigger_broker/tunnel.py
@@ -39,10 +39,6 @@ PMTU_PROBE_SIZE_COUNT = len(PMTU_PROBE_SIZES)
 PMTU_PROBE_REPEATS = 4
 PMTU_PROBE_COMBINATIONS = PMTU_PROBE_SIZE_COUNT * PMTU_PROBE_REPEATS
 
-# Session feature flags
-FEATURE_UNIQUE_SESSION_ID = 1 << 0
-FEATURES_MASK = FEATURE_UNIQUE_SESSION_ID
-
 # Logger.
 logger = logging.getLogger("tunneldigger.tunnel")
 
@@ -78,8 +74,8 @@ class Tunnel(protocol.HandshakeProtocolMixin, network.Pollable):
         self.client_features = client_features
         self.tunnel_id = tunnel_id
         self.remote_tunnel_id = remote_tunnel_id
-        self.session_id = self.tunnel_id if self.client_features & FEATURE_UNIQUE_SESSION_ID else 1
-        self.remote_session_id = self.remote_tunnel_id if self.client_features & FEATURE_UNIQUE_SESSION_ID else 1
+        self.session_id = self.tunnel_id if self.client_features & protocol.FEATURE_UNIQUE_SESSION_ID else 1
+        self.remote_session_id = self.remote_tunnel_id if self.client_features & protocol.FEATURE_UNIQUE_SESSION_ID else 1
 
         self.last_alive = time.time()
         self.created_time = None
@@ -180,7 +176,7 @@ class Tunnel(protocol.HandshakeProtocolMixin, network.Pollable):
         self.created_time = time.time()
 
         # Respond with tunnel establishment message.
-        server_features = self.client_features & FEATURES_MASK
+        server_features = self.client_features & protocol.FEATURES_MASK
         if server_features:
             # Tell the client which features we support.
             msg = struct.pack('!II', self.tunnel_id, server_features)

--- a/broker/src/tunneldigger_broker/tunnel.py
+++ b/broker/src/tunneldigger_broker/tunnel.py
@@ -118,6 +118,9 @@ class Tunnel(protocol.HandshakeProtocolMixin, network.Pollable):
         except l2tp.L2TPTunnelExists:
             self.socket.close()
             raise
+        except l2tp.L2TPSessionExists:
+            self.socket.close()
+            raise
         except l2tp.NetlinkError:
             self.socket.close()
             raise TunnelSetupFailed


### PR DESCRIPTION
Quoting the main commit message:

```
    L2TPv3 session IDs have to be unique on the entire system, not just per tunnel.
    The only reason that tunneldigger got away with using 1 for all sessions is that
    older Linux kernels failed to properly check for duplicate session IDs.  That
    got fixed by kernel commit dbdbc73b44782e22b3b4b6e8b51e7a3d245f3086.
    
    This patch adds unique session IDs to tunneldigger in a backwards-compatible
    way.  If both ends of the tunnel agree to use a unique session ID, they both
    will use the tunnel ID as the session ID.  To manage this mutual agreement, we
    introduce space for up to 32 feature flags.  Three messages are affected:
    
    CONTROL_TYPE_USAGE optionally takes 4 additional bytes after the padding, used
    to send the client's feature flags.  Brokers may skew the usage they report back
    depending on client features.  Old clients will not send these bytes, which is
    interpreted as all flags being 0.
    
    CONTROL_TYPE_PREPARE is extended the same way, also sending the client's feature
    flags, so that the server does not have to remember them.  These are the
    features that the client is offering to be using for this session.  Old clients
    will not send any flags, which tells the server that no features are supported.
    Old servers will ignore flags if they received them.
    
    CONTROL_TYPE_TUNNEL is extended the same way, reporting the features that are
    actually going to be used for this session.  Typically, this will be the
    client's features masked by what the server supports.  If a feature-aware client
    talks to an old server, the flags are going to be missing, telling the client
    that no features are going to be used in this session.
    
    The first feature flag is 'unique session IDs'.  If enabled, the session ID of
    each side of the connection is going to be the same as the tunnel ID.
    Furthermore, the broker gains an option to report full usage for clients not
    supporting unique session IDs, making sure they connect to other servers (if any
    are available).
```

I think this is ready to be reviewed. However, before merging, I'd like to
* [x] roll out an experimental firmware showing that the client stuff really works, and 
* [x] at least try to figure out why we still have two clients connecting to the Gateway that now should report usage 0xFFFF.

Fixes #57