### PR TITLE
client: Quicker reconnect on broker failure

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -2,3 +2,4 @@ CMakeCache.txt
 CMakeFiles
 Makefile
 cmake_install.cmake
+build

--- a/client/l2tp_client.c
+++ b/client/l2tp_client.c
@@ -1386,6 +1386,10 @@ int main(int argc, char **argv)
     // Make sure all brokers are in sane state.
     for (i = 0; i < broker_cnt; i++) {
       context_reinitialize(brokers[i].ctx);
+      if (brokers[i].broken && brokers[i].broken + 3600 < timer_now()) {
+        // This one broke more than an hour ago, give it another chance.
+        brokers[i].broken = 0;
+      }
       if (!brokers[i].broken)
         working_brokers += 1;
     }
@@ -1455,7 +1459,7 @@ int main(int argc, char **argv)
     // Initially, we mark this broker as broken.  We will remove this mark after establishing
     // a connection.  We only want to consider a broker as broker if the initial connection fails;
     // disconnecting later (e.g. because the broker got restarted) is fine.
-    brokers[i].broken = 1;
+    brokers[i].broken = timer_now();
 
     // Perform processing on the main context; if the connection fails and does
     // not recover after 30 seconds, restart the broker selection process.

--- a/client/l2tp_client.c
+++ b/client/l2tp_client.c
@@ -1504,7 +1504,9 @@ int main(int argc, char **argv)
       }
 
       // If the connection is lost, we start the reconnection timer.
-      // Hitting this code path should not be possible, but lets play safe.
+      // Hitting this code path should not be possible:  Once we are in STATE_KEEPALIVE
+      // (which is a prerequisite for ever having `timer_establish < 0`),
+      // the only possible transition is to STATE_FAILED.  But let's play safe.
       if (timer_establish < 0 && main_context->state != STATE_KEEPALIVE) {
         timer_establish = timer_now();
       }

--- a/client/l2tp_client.c
+++ b/client/l2tp_client.c
@@ -1468,9 +1468,6 @@ int main(int argc, char **argv)
       if (main_context->state == STATE_REINIT) {
         syslog(LOG_ERR, "Connection to %s lost.", main_context->broker_hostname);
         break;
-      } else if (main_context->state == STATE_KEEPALIVE) {
-        // We successfully established a connection, this broker is fine.
-        brokers[i].broken = 0;
       }
 
       // If the connection is lost, we start the reconnection timer.
@@ -1486,6 +1483,9 @@ int main(int argc, char **argv)
           syslog(LOG_ERR, "Connection with broker not established after 30 seconds, restarting broker selection...");
           break;
         }
+
+        // We successfully established a connection, this broker is fine.
+        brokers[i].broken = 0;
 
         timer_establish = -1;
         restart_timer = 1;


### PR DESCRIPTION
This drops support for brokers that do not reply to a USAGE query. The advantage of that is that we can already tell from the state we are in whether we are in the "first phase" (scanning all brokers to see which ones are available) or the "second phase" (establishing and maintaining a tunnel with the broker).

Based on that, we can drop `standby_only`. We can also make sure that, once we are in the "second phase", if we ever jump to the "first phase" again, the main loop restarts the entire thing. I also decreased some timeouts to minimize the downtime in case a broker is shut down or restarted.

Before this patch, restarting a broker (if all other brokers are running) had a downtime of around 30s (until the main loop realizes that the connection is gone). This is despite the fact that the client got an ERROR, telling it that the broker went away! Stopping a broker (or restarting a broker while another broker is down) even lead to a downtime of 50s, because the client waits for 20s until it realizes that no reply is going to come to its USAGE query. With this patch, in both cases, the downtime is below 10s.

Fixes #65 