### PR TITLE
Add a way to disable client-side MTU discovery

### DIFF
--- a/broker/l2tp_broker.cfg.example
+++ b/broker/l2tp_broker.cfg.example
@@ -19,7 +19,9 @@ tunnel_id_base=100
 namespace=default
 ; Reject connections if there are less than N seconds since the last connection
 connection_rate_limit=10
-; Set PMTU to a fixed value.  Use 0 for automatic PMTU discovery.
+; Set PMTU to a fixed value.  Use 0 for automatic PMTU discovery.  A non-0 value also disables
+; PMTU discovery on the client side, by having the server not respond to client-side PMTU
+; discovery probes.
 pmtu=0
 
 [log]

--- a/broker/src/tunneldigger_broker/tunnel.py
+++ b/broker/src/tunneldigger_broker/tunnel.py
@@ -373,8 +373,11 @@ class Tunnel(protocol.HandshakeProtocolMixin, network.Pollable):
             self.close(reason=protocol.ERROR_REASON_FROM_SERVER | protocol.ERROR_REASON_OTHER_REQUEST)
             return True
         elif msg_type == protocol.CONTROL_TYPE_PMTUD:
-            # The other side is performing PMTU discovery.
-            self.write_message(self.endpoint, protocol.CONTROL_TYPE_PMTUD_ACK, struct.pack('!H', raw_length))
+            # The other side is performing PMTU discovery.  Only cooperate if automatic MTU discovery is
+            # enabled for this network.
+            pmtu_probe = struct.pack('!H', raw_length)
+            if self.automatic_pmtu:
+                self.write_message(self.endpoint, protocol.CONTROL_TYPE_PMTUD_ACK, pmtu_probe)
             return True
         elif msg_type == protocol.CONTROL_TYPE_PMTUD_ACK:
             # The other side is acknowledging a specific PMTU value.

--- a/client/l2tp_client.c
+++ b/client/l2tp_client.c
@@ -925,6 +925,7 @@ int context_session_set_mtu(l2tp_context *ctx)
   uint16_t mtu = ctx->pmtu - L2TP_TUN_OVERHEAD;
   if (ctx->peer_pmtu > 0 && ctx->peer_pmtu < mtu)
     mtu = ctx->peer_pmtu;
+  syslog(LOG_INFO, "Setting MTU to %d", (int) mtu);
 
   // Update the device MTU.
   struct ifreq ifr;


### PR DESCRIPTION
Right now we have clients change the MTU on their end of the tunnel even though PMTU discovery is disabled on the server. Not responding to `CONTROL_TYPE_PMTUD` fixes that.

Changing the tunnel MTU is not working well when using batman, which does not adapt to changing MTUs.