### PR TITLE
client: Switch libnl-tiny and libnl in cmake

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -1,22 +1,32 @@
 cmake_minimum_required(VERSION 2.8)
 project (tunneldigger)
 
+set(USE_LIBNL FALSE CACHE BOOL "Explicitly use libnl over libnl-tiny")
+set(USE_LIBNL_TINY FALSE CACHE BOOL "Explicitly use libnl-tiny over libnl")
+
 find_package(PkgConfig)
 
-pkg_check_modules(LIBNL libnl-3.0 libnl-genl-3.0)
-if(NOT LIBNL_FOUND)
-    pkg_check_modules(LIBNL REQUIRED libnl-tiny)
+if(USE_LIBNL AND USE_LIBNL_TINY)
+	message(FATAL_ERROR "libnl and libnl-tiny cannot be used together")
+elseif(USE_LIBNL_TINY)
+	pkg_check_modules(LIBNL REQUIRED libnl-tiny)
+elseif(NOT USE_LIBNL)
+	pkg_check_modules(LIBNL libnl-tiny)
+endif()
+
+if(NOT LIBNL_FOUND OR USE_LIBNL)
+	pkg_check_modules(LIBNL REQUIRED libnl-3.0 libnl-genl-3.0)
 endif()
 
 pkg_check_modules(LIBASYNCNS libasyncns)
 if(LIBASYNCNS_FOUND)
-	ADD_DEFINITIONS("-DUSE_SHARED_LIBASYNCNS=1")
+	add_definitions("-DUSE_SHARED_LIBASYNCNS=1")
 	add_executable(tunneldigger l2tp_client.c)
 else()
 	add_executable(tunneldigger l2tp_client.c libasyncns/asyncns.c)
 endif()
 
-INCLUDE_DIRECTORIES(
+include_directories(
 	${LIBASYNCNS_INCLUDE_DIRS}
 	${LIBNL_INCLUDE_DIRS}
 	${LIBNL_TINY_INCLUDE_DIRS}
@@ -31,4 +41,4 @@ target_link_libraries(tunneldigger
 	-lrt
 )
 
-INSTALL(TARGETS tunneldigger DESTINATION bin)
+install(TARGETS tunneldigger DESTINATION bin)


### PR DESCRIPTION
This issue unfortunately popped up after I commited the cmake file.

In LEDE/OpenWrt buildroots cmake will find the full libnl first if both
are available in the buildroot.

Switching the two alternatives will give preference to libnl-tiny, which
is what most likely will end up in the image.

Also this introduces a flag to force which libnl implementation is to be
used. This allows for more control over the build process while
maintaining the convenience of autodetection in most other environments.

A few style fixes are included as well, namely changing all command
invocations to lowercase consistently throughout the file.

Signed-off-by: Felix Kaechele <felix@kaechele.ca>