### PR TITLE
allow fractions of seconds for the rate limit

### DIFF
--- a/broker/l2tp_broker.cfg.example
+++ b/broker/l2tp_broker.cfg.example
@@ -17,7 +17,8 @@ tunnel_id_base=100
 ; configure disjunct ports, and tunnel identifiers in order for
 ; namespacing to work
 namespace=default
-; Reject connections if there are less than N seconds since the last connection
+; Reject connections if there are less than N seconds since the last connection.
+; Can be less than a second (e.g., 0.1).
 connection_rate_limit=10
 ; Set PMTU to a fixed value.  Use 0 for automatic PMTU discovery.  A non-0 value also disables
 ; PMTU discovery on the client side, by having the server not respond to client-side PMTU

--- a/broker/src/tunneldigger_broker/main.py
+++ b/broker/src/tunneldigger_broker/main.py
@@ -77,7 +77,7 @@ tunnel_manager = broker.TunnelManager(
     tunnel_id_base=config.getint('broker', 'tunnel_id_base'),
     tunnel_port_base=config.getint('broker', 'port_base'),
     namespace=config.get('broker', 'namespace'),
-    connection_rate_limit=config.getint('broker', 'connection_rate_limit'),
+    connection_rate_limit=config.getfloat('broker', 'connection_rate_limit'),
     pmtu_fixed=config.getint('broker', 'pmtu'),
     log_ip_addresses=config.getboolean('log', 'log_ip_addresses'),
 )


### PR DESCRIPTION
I have this now set to 0.1 seconds on our servers, and that works very well to distribute floods of clients (occurring when another server goes down).