### PR TITLE
pass the local broker port to the session setup scripts

### DIFF
--- a/broker/scripts/setup_interface.sh
+++ b/broker/scripts/setup_interface.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 TUNNEL_ID="$1"
+SESSION_ID="$2"
 INTERFACE="$3"
 MTU="$4"
+ENDPOINT_IP="$5"
+ENDPOINT_PORT="$6"
+LOCAL_PORT="$7"
+UUID="$8"
+LOCAL_BROKER_PORT="$9"
 
 . scripts/bridge_functions.sh
 

--- a/broker/scripts/teardown_interface.sh
+++ b/broker/scripts/teardown_interface.sh
@@ -2,6 +2,11 @@
 TUNNEL_ID="$1"
 INTERFACE="$3"
 MTU="$4"
+ENDPOINT_IP="$5"
+ENDPOINT_PORT="$6"
+LOCAL_PORT="$7"
+UUID="$8"
+LOCAL_BROKER_PORT="$9"
 
 # Remove the interface from our bridge
 brctl delif digger${MTU} $INTERFACE

--- a/broker/src/tunneldigger_broker/tunnel.py
+++ b/broker/src/tunneldigger_broker/tunnel.py
@@ -209,6 +209,7 @@ class Tunnel(protocol.HandshakeProtocolMixin, network.Pollable):
             self.endpoint[1],
             self.address[1],
             self.uuid,
+            self.broker.address[1],
         )
 
     def pmtu_discovery(self):
@@ -306,6 +307,7 @@ class Tunnel(protocol.HandshakeProtocolMixin, network.Pollable):
             self.endpoint[1],
             self.address[1],
             self.uuid,
+            self.broker.address[1],
         )
 
         self.broker.netlink.session_delete(self.tunnel_id, self.session_id)
@@ -321,6 +323,7 @@ class Tunnel(protocol.HandshakeProtocolMixin, network.Pollable):
             self.endpoint[1],
             self.address[1],
             self.uuid,
+            self.broker.address[1],
         )
 
         # Transmit error message so the other end can tear down the tunnel

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -131,7 +131,8 @@ There are currently four different hooks, namely:
   the higher layers (example of such a script is found under ``scripts/setup_interface.sh``)
 
 * ``session.pre-down`` is called just before the tunnel interface is going to be removed by the broker (example is
-  found under ``scripts/teardown_interface.sh``)
+  found under ``scripts/teardown_interface.sh``).  Notice that hooks are executed asynchonously, so by the time
+  this script runs, the interface may already be gone.
 
 * ``session.down`` is called after the tunnel interface has been destroyed and is no longer available (we currently
   do not use this hook)


### PR DESCRIPTION
We are using the local broker port (i.e., the one that the clients connect to) to distinguish which of several networks the client is going to be added to.  To do that, we need this information to be available in the session-up script.