### PR TITLE
Python 3 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ branches:
     - master
 language: python
 python:
- - 2.7
+ - 3.6
 sudo: required
 dist: bionic
 install:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,13 @@
 vNEXT
 -----
 
+* Python 3 support.
+  Python 2 is no longer supported.
+  **NOTE:** If you are running the broker in a Python virtualenv you will have to
+  rebuild the virtualenv using a Python 3 interpreter.
+  This can be achieved by deleting the old virtualenv folder and recreating it.
+  For recreating the virtualenv you can refer to the "Installation" section of
+  the broker `installation chapter in the Tunneldigger documentation`_.
 * Fixed compatibility with new Linux kernels on the broker side: New kernels
   force the l2tpv3 session ID to be unique system-wide, while old tunneldigger
   clients have a hard-coded ID of 1 for both ends of the tunnel. When a new
@@ -16,6 +23,8 @@ vNEXT
   probes.
 * Improve client behavior on broker failure, and decrease some reconnect
   timeouts.
+
+.. _`installation chapter in the Tunneldigger documentation`: https://tunneldigger.readthedocs.io/en/latest/server.html#installation
 
 v0.3.0, 2017-Apr-02
 -------------------

--- a/broker/setup.py
+++ b/broker/setup.py
@@ -29,7 +29,6 @@ setup(
     ],
     install_requires=[
         'netfilter>=0.6.2',
-        'six>=1.10.0',
         'cffi>=1.4.1',
     ],
     extras_require={},

--- a/broker/setup.py
+++ b/broker/setup.py
@@ -21,6 +21,7 @@ setup(
         'Intended Audience :: System Administrators',
         'License :: OSI Approved :: GNU Affero General Public License v3',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 3 :: Only',
     ],
     include_package_data=True,
     zip_safe=False,

--- a/broker/src/_ffi_src/build_conntrack.py
+++ b/broker/src/_ffi_src/build_conntrack.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function
+
 
 from cffi import FFI
 

--- a/broker/src/tunneldigger_broker/broker.py
+++ b/broker/src/tunneldigger_broker/broker.py
@@ -3,7 +3,7 @@ import socket
 import time
 import traceback
 
-import conntrack
+from . import conntrack
 import netfilter.table
 import netfilter.rule
 
@@ -42,7 +42,7 @@ class TunnelManager(object):
         self.hook_manager = hook_manager
         self.max_tunnels = max_tunnels
         self.tunnel_id_base = tunnel_id_base
-        self.tunnel_ids = set(xrange(tunnel_id_base, tunnel_id_base + max_tunnels))
+        self.tunnel_ids = set(range(tunnel_id_base, tunnel_id_base + max_tunnels))
         self.tunnel_port_base = tunnel_port_base
         self.namespace = namespace
         self.tunnels = {}
@@ -117,11 +117,11 @@ class TunnelManager(object):
             self.last_tunnel_created = now
         except KeyboardInterrupt:
             raise
-        except l2tp.L2TPTunnelExists, e:
+        except l2tp.L2TPTunnelExists as e:
             # Do not return the tunnel identifier into the pool.
             logger.warning("Tunnel identifier %d already exists." % e.tunnel_id)
             return False
-        except l2tp.L2TPSessionExists, e:
+        except l2tp.L2TPSessionExists as e:
             # Return tunnel identifier into the pool.
             self.tunnel_ids.add(tunnel_id)
             logger.warning("Session identifier %d already exists." % e.session_id)
@@ -208,7 +208,7 @@ class TunnelManager(object):
         manager instance should not be used after calling this method.
         """
 
-        for tunnel in self.tunnels.values():
+        for tunnel in list(self.tunnels.values()):
             try:
                 tunnel.close()
             except:

--- a/broker/src/tunneldigger_broker/genetlink.py
+++ b/broker/src/tunneldigger_broker/genetlink.py
@@ -7,8 +7,8 @@ GPLv2+; See copying for details.
 '''
 
 import struct
-from netlink import NLM_F_REQUEST, NLMSG_MIN_TYPE, Message, parse_attributes
-from netlink import NulStrAttr, Connection, NETLINK_GENERIC
+from .netlink import NLM_F_REQUEST, NLMSG_MIN_TYPE, Message, parse_attributes
+from .netlink import NulStrAttr, Connection, NETLINK_GENERIC
 
 CTRL_CMD_UNSPEC       = 0
 CTRL_CMD_NEWFAMILY    = 1

--- a/broker/src/tunneldigger_broker/hooks.py
+++ b/broker/src/tunneldigger_broker/hooks.py
@@ -55,7 +55,7 @@ class HookProcess(object):
         Closes the hook process.
         """
 
-        for line in self.buffer.getvalue().split('\n'):
+        for line in self.buffer.getvalue().decode('utf-8').split('\n'):
             if not line:
                 continue
 
@@ -118,7 +118,7 @@ class HookManager(object):
 
 
         def sigchld_handler(signal_number, frame):
-            os.write(pipe_w, '\x00')
+            os.write(pipe_w, b'\x00')
 
         signal.signal(signal.SIGCHLD, sigchld_handler)
         event_loop.register(self, pipe_r, select.EPOLLIN)

--- a/broker/src/tunneldigger_broker/hooks.py
+++ b/broker/src/tunneldigger_broker/hooks.py
@@ -153,7 +153,7 @@ class HookManager(object):
             process = HookProcess(name, script, args)
             process.register(self.event_loop)
             self.processes[process.process.pid] = process
-        except OSError, e:
+        except OSError as e:
             logger.error("Error while executing script '%s': %s" % (script, e))
 
     def close(self):

--- a/broker/src/tunneldigger_broker/l2tp.py
+++ b/broker/src/tunneldigger_broker/l2tp.py
@@ -1,5 +1,5 @@
-import netlink
-import genetlink
+from . import netlink
+from . import genetlink
 import logging
 import traceback
 import errno
@@ -106,7 +106,7 @@ class NetlinkInterface(object):
 
         try:
             self.connection.recv()
-        except OSError, e:
+        except OSError as e:
             if e.errno == errno.EEXIST:
                 # This tunnel identifier is already in use; make sure to remove it from
                 # our pool of assignable tunnel identifiers.
@@ -172,7 +172,7 @@ class NetlinkInterface(object):
 
         try:
             self.connection.recv()
-        except OSError, e:
+        except OSError as e:
             if e.errno == errno.EEXIST:
                 raise L2TPSessionExists(session_id)
 

--- a/broker/src/tunneldigger_broker/main.py
+++ b/broker/src/tunneldigger_broker/main.py
@@ -1,4 +1,4 @@
-import ConfigParser
+import configparser
 import logging
 import logging.config
 import os
@@ -8,18 +8,18 @@ import sys
 from . import broker, eventloop, hooks
 
 if os.getuid() != 0:
-    print "ERROR: The tunneldigger broker must be run as root."
+    print("ERROR: The tunneldigger broker must be run as root.")
     sys.exit(1)
 
 # Load configuration.
-config = ConfigParser.SafeConfigParser()
+config = configparser.SafeConfigParser()
 try:
     config.read(sys.argv[1])
 except IOError:
-    print "ERROR: Failed to open the specified configuration file '%s'!" % sys.argv[1]
+    print("ERROR: Failed to open the specified configuration file '%s'!" % sys.argv[1])
     sys.exit(1)
 except IndexError:
-    print "ERROR: First argument must be a configuration file path!"
+    print("ERROR: First argument must be a configuration file path!")
     sys.exit(1)
 
 # Configure logging.
@@ -64,7 +64,7 @@ for hook in ('session.up', 'session.pre-down', 'session.down', 'session.mtu-chan
         script = config.get('hooks', hook).strip()
         if not script:
             continue
-    except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
+    except (configparser.NoOptionError, configparser.NoSectionError):
         continue
 
     hook_manager.register_hook(hook, script)

--- a/broker/src/tunneldigger_broker/main.py
+++ b/broker/src/tunneldigger_broker/main.py
@@ -12,7 +12,7 @@ if os.getuid() != 0:
     sys.exit(1)
 
 # Load configuration.
-config = configparser.SafeConfigParser()
+config = configparser.ConfigParser()
 try:
     config.read(sys.argv[1])
 except IOError:

--- a/broker/src/tunneldigger_broker/netlink.py
+++ b/broker/src/tunneldigger_broker/netlink.py
@@ -37,7 +37,7 @@ class Attr:
         hdr = struct.pack("HH", len(self.data)+4, self.type)
         length = len(self.data)
         pad = ((length + 4 - 1) & ~3) - length
-        return hdr + self.data + '\0' * pad
+        return hdr + self.data + b'\0' * pad
 
     def __repr__(self):
         return '<Attr type %d, data "%s">' % (self.type, repr(self.data))
@@ -59,11 +59,11 @@ class Attr:
 
 class StrAttr(Attr):
     def __init__(self, attr_type, data):
-        Attr.__init__(self, attr_type, "%ds" % len(data), data)
+        Attr.__init__(self, attr_type, "%ds" % len(data), data.encode('utf-8'))
 
 class NulStrAttr(Attr):
     def __init__(self, attr_type, data):
-        Attr.__init__(self, attr_type, "%dsB" % len(data), data, 0)
+        Attr.__init__(self, attr_type, "%dsB" % len(data), data.encode('utf-8'), 0)
 
 class U32Attr(Attr):
     def __init__(self, attr_type, val):
@@ -120,7 +120,7 @@ class Message:
             contents = []
             for attr in payload:
                 contents.append(attr._dump())
-            self.payload = ''.join(contents)
+            self.payload = b''.join(contents)
         else:
             self.payload = payload
 

--- a/broker/src/tunneldigger_broker/network.py
+++ b/broker/src/tunneldigger_broker/network.py
@@ -1,6 +1,6 @@
 import os
 import errno
-import timerfd
+from . import timerfd
 import logging
 import traceback
 import select

--- a/broker/src/tunneldigger_broker/network.py
+++ b/broker/src/tunneldigger_broker/network.py
@@ -36,7 +36,7 @@ class Pollable(object):
 
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.socket.bind(address)
-        self.socket.setsockopt(socket.SOL_SOCKET, SO_BINDTODEVICE, interface)
+        self.socket.setsockopt(socket.SOL_SOCKET, SO_BINDTODEVICE, interface.encode('utf-8'))
 
         self.address = address
         self.interface = interface
@@ -124,7 +124,7 @@ class Pollable(object):
         except socket.error:
             return
 
-    def write_message(self, address, msg_type, msg_data=''):
+    def write_message(self, address, msg_type, msg_data=b''):
         """
         Writes a protocol message into the underlying UDP socket.
 
@@ -135,14 +135,14 @@ class Pollable(object):
 
         assert len(msg_data) < 255
 
-        data = '\x80\x73\xA7\x01'
+        data = b'\x80\x73\xA7\x01'
         data += struct.pack('!BB', msg_type, len(msg_data))
         data += msg_data
 
         # Pad the message to be at least 12 bytes long, as otherwise some firewalls
         # may filter it when used over port 53.
         if len(data) < 12:
-            data += '\x00' * (12 - len(data))
+            data += b'\x00' * (12 - len(data))
 
         self.write(address, data)
 

--- a/broker/src/tunneldigger_broker/protocol.py
+++ b/broker/src/tunneldigger_broker/protocol.py
@@ -113,7 +113,7 @@ class HandshakeProtocolMixin(object):
             #           over (src_host, src_port, random_bytes)
             timestamp = struct.pack('!H', protocol_time())
             signed_value = '%s%s%s' % (address[0], address[1], timestamp)
-            signature = hmac.HMAC(SECRET_KEY, signed_value, hashlib.sha1).digest()[:6]
+            signature = hmac.HMAC(SECRET_KEY, signed_value.encode('utf-8'), hashlib.sha1).digest()[:6]
             self.write_message(address, CONTROL_TYPE_COOKIE, timestamp + signature)
         elif msg_type == CONTROL_TYPE_PREPARE:
             # Packet format:
@@ -130,7 +130,7 @@ class HandshakeProtocolMixin(object):
             timestamp = msg_data[offset:offset + 2]
             offset += 2
             signed_value = '%s%s%s' % (address[0], address[1], timestamp)
-            signature = hmac.HMAC(SECRET_KEY, signed_value, hashlib.sha1).digest()[:6]
+            signature = hmac.HMAC(SECRET_KEY, signed_value.encode('utf-8'), hashlib.sha1).digest()[:6]
             timestamp = struct.unpack('!H', timestamp)[0]
 
             # Reject message if more than 2 protocol ticks old.  One tick is 1 >> 6 = 64 seconds.
@@ -138,9 +138,9 @@ class HandshakeProtocolMixin(object):
                 return
             offset += 6
 
-            uuid_len = struct.unpack('!B', msg_data[offset])[0]
+            uuid_len = msg_data[offset]
             offset += 1
-            uuid = msg_data[offset:offset + uuid_len]
+            uuid = msg_data[offset:offset + uuid_len].decode('utf-8')
             offset += uuid_len
 
             # Parse optional data

--- a/broker/src/tunneldigger_broker/tunnel.py
+++ b/broker/src/tunneldigger_broker/tunnel.py
@@ -227,12 +227,12 @@ class Tunnel(protocol.HandshakeProtocolMixin, network.Pollable):
             self.create_timer(self.pmtu_discovery, timeout=random.randrange(500, 700))
             return
 
-        self.pmtu_probe_size = PMTU_PROBE_SIZES[self.pmtu_probe_iteration / PMTU_PROBE_REPEATS]
+        self.pmtu_probe_size = PMTU_PROBE_SIZES[int(self.pmtu_probe_iteration / PMTU_PROBE_REPEATS)]
         self.pmtu_probe_iteration = (self.pmtu_probe_iteration + 1) % PMTU_PROBE_COMBINATIONS
 
         # Transmit the PMTU probe.
-        probe = '\x80\x73\xA7\x01\x06\x00'
-        probe += '\x00' * (self.pmtu_probe_size - IPV4_HDR_OVERHEAD - len(probe))
+        probe = b'\x80\x73\xA7\x01\x06\x00'
+        probe += b'\x00' * (self.pmtu_probe_size - IPV4_HDR_OVERHEAD - len(probe))
         self.write(self.endpoint, probe)
 
         # Wait some to get the reply.
@@ -253,7 +253,7 @@ class Tunnel(protocol.HandshakeProtocolMixin, network.Pollable):
 
         # Alter tunnel MTU.
         try:
-            interface_name = (self.get_session_name() + '\x00' * 16)[:16]
+            interface_name = (self.get_session_name().encode('utf-8') + b'\x00' * 16)[:16]
             data = struct.pack("16si", interface_name, self.tunnel_mtu)
             fcntl.ioctl(self.socket, SIOCSIFMTU, data)
         except IOError:

--- a/broker/src/tunneldigger_broker/tunnel.py
+++ b/broker/src/tunneldigger_broker/tunnel.py
@@ -1,4 +1,4 @@
-import conntrack
+from . import conntrack
 import fcntl
 import logging
 import netfilter.table

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -137,10 +137,18 @@ If we assume that you are installing Tunneldigger under ``/srv/tunneldigger``
 (the scripts provided with Tunneldigger assume that as well), you can do::
 
     cd /srv/tunneldigger
-    virtualenv env_tunneldigger
+    virtualenv -p /usr/bin/python3 env_tunneldigger
 
-This creates the virtual environment. You can then checkout the Tunneldigger
-repository into ``/srv/tunneldigger/tunneldigger`` by doing::
+.. note::
+    Tunneldigger only supports Python 3.
+    
+    Using the above command ensures the virtualenv is created using a Python 3 interpreter.
+    In case the Python 3 interpreter you would like to use is not located at ``/usr/bin/python3`` you will have to adjust the path accordingly.
+    If your distribution uses Python 3 by default you can usually omit the ``-p`` parameter.
+
+This creates a virtual Python environment in the ``env_tunneldigger`` folder. This
+folder can be deleted and recreated as needed using the virtualenv command, should this be required.
+You can then checkout the Tunneldigger repository into ``/srv/tunneldigger/tunneldigger`` by doing::
 
     cd /srv/tunneldigger
     git clone https://github.com/wlanslovenija/tunneldigger.git

--- a/tests/prepare_server.sh
+++ b/tests/prepare_server.sh
@@ -40,7 +40,11 @@ lighttpd -f /tmp/lighttpd.conf
 
 # setup virtualenv
 cd /srv/
-virtualenv env_tunneldigger
+if grep -Fq 'Python :: 3 :: Only' /srv/tunneldigger/broker/setup.py; then
+    virtualenv -p /usr/bin/python3 env_tunneldigger
+else
+    virtualenv -p /usr/bin/python2 env_tunneldigger
+fi
 
 . /srv/env_tunneldigger/bin/activate
 if [ -f /srv/tunneldigger/broker/setup.py ]; then

--- a/tests/tunneldigger.py
+++ b/tests/tunneldigger.py
@@ -49,6 +49,7 @@ def setup_template(ubuntu_release):
         "bridge-utils",
         "libnetfilter-conntrack3",
         "python-dev",
+        "python3-dev",
         "libevent-dev",
         "ebtables",
         "python-virtualenv",
@@ -148,7 +149,7 @@ def generate_test_file():
 
 def testing(client_rev, server_rev):
     context = get_random_context()
-    print("generate a run for %s" % context)
+    print(("generate a run for %s" % context))
     client, server = prepare_containers(context, client_rev, server_rev)
     spid = run_server(server)
     cpid = run_client(client, ['-b', '172.16.16.1:8942'])


### PR DESCRIPTION
This is a first stab at Python 3 support.
From my testing, it should be complete.
Coverage report from running the broker with the default config and connecting a client as well as connecting a client with a set bandwidth limit:

```
Name                 Stmts   Miss  Cover
----------------------------------------
__init__.py              0      0   100%
_ffi/__init__.py         0      0   100%
broker.py              132     29    78%
conntrack.py            76     13    83%
eventloop.py            26      1    96%
genetlink.py            59      1    98%
hooks.py                91      8    91%
l2tp.py                106     29    73%
limits.py               28      9    68%
main.py                 63     17    73%
netlink.py             160     24    85%
network.py              88     18    80%
protocol.py             95     12    87%
timerfd.py              80     25    69%
traffic_control.py      15      1    93%
tunnel.py              184     53    71%
----------------------------------------
TOTAL                 1203    240    80%
```
Areas that are uncovered are mainly untriggered error states.

Tested and working on:
```
python2-2.7.16-4.fc31.x86_64
python3-3.7.4-5.fc31.x86_64
```