### PR TITLE
client: declare project as C

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8)
-project (tunneldigger)
+project (tunneldigger C)
 
 set(USE_LIBNL FALSE CACHE BOOL "Explicitly use libnl over libnl-tiny")
 set(USE_LIBNL_TINY FALSE CACHE BOOL "Explicitly use libnl-tiny over libnl")


### PR DESCRIPTION
This prevents cmake from looking for a C++ compiler.

Signed-off-by: Felix Kaechele <felix@kaechele.ca>