### PR TITLE
Update top-level docs

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,7 +1,7 @@
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -643,7 +643,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU Affero General Public License for more details.
 
     You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -658,4 +658,4 @@ specific requirements.
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU AGPL, see
-<http://www.gnu.org/licenses/>.
+<https://www.gnu.org/licenses/>.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2012-2015 wlan slovenija, open wireless network of Slovenia
+Copyright (C) 2012-2020 wlan slovenija, open wireless network of Slovenia
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU Affero General Public License as published by the Free
@@ -11,7 +11,7 @@ PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
 details.
 
 You should have received a copy of the GNU Affero General Public License along
-with this program.  If not, see <http://www.gnu.org/licenses/>.
+with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Together with the source code this program may contain also additional content.
 Unless specified otherwise, this content is available under Creative Commons
@@ -19,13 +19,13 @@ Attribution-ShareAlike license, either version 3.0 of the license, or (at your
 option) any later version.  You are free to copy, distribute, transmit, adapt
 and/or commercially use this content or part(s) of it, provided you publicly,
 clearly and visibly attribute wlan slovenija, open wireless network of
-Slovenia, and provide a link to its website <http://wlan-si.net/>, if
+Slovenia, and provide a link to its website <https://wlan-si.net/>, if
 applicable.  If you alter, transform, or build upon this content or part(s) of
 it, you may distribute the results only under the same or similar license to
 this one.
 
 For more information about Creative Commons Attribution-ShareAlike license see
-<http://creativecommons.org/>.
+<https://creativecommons.org/>.
 
 This program may contain, use, link to and/or distribute also parts under third
 party copyright with possibly different licensing conditions. Make sure you

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,13 @@
 Tunneldigger
 ============
 
+L2TPv3 VPN tunneling solution
+
 .. image:: https://travis-ci.org/wlanslovenija/tunneldigger.svg?branch=master
     :target: https://travis-ci.org/wlanslovenija/tunneldigger
+
+About
+-----
 
 Tunneldigger is one of the projects of `wlan slovenija`_ open wireless network.
 It is a simple VPN tunneling solution based on L2TPv3 tunnels supported in
@@ -10,43 +15,52 @@ recent Linux kernels.
 
 .. _wlan slovenija: https://wlan-si.net
 
-Documentation is found at:
+It consists of a client and a server portion referred to as the broker. The
+client is optimized to run on embedded devices such as wireless routers
+running OpenWrt_.
 
-http://tunneldigger.readthedocs.org/
+.. _OpenWrt: https://openwrt.org
 
-Opkg (OpenWrt) packages for both Tunneldigger client and broker are available at:
+The client is written in C to allow for smaller binary size whereas the server
+portion, referred to as the broker, is written in Python.
 
-https://github.com/wlanslovenija/firmware-packages-opkg
+Installation and Use
+--------------------
 
-Source Code, Issue Tracker and Mailing List
+Information on set up and use of Tunneldigger can be found in the
+documentation:
+
+https://tunneldigger.readthedocs.org/
+
+Source Code and Issue Tracker
 -------------------------------------------
 
-For development *wlan slovenija* open wireless network `development Trac`_ is
-used, so you can see `existing open tickets`_ or `open a new one`_ there. Source
-code is available on GitHub_. If you have any questions or if you want to
-discuss the project, use `development mailing list`_.
+Development happens on GitHub_ and issues can be filed in the `Issue tracker`_.
 
-.. _development Trac: https://dev.wlan-si.net/wiki/Tunneldigger
-.. _existing open tickets: https://dev.wlan-si.net/report/15
-.. _open a new one: https://dev.wlan-si.net/newticket
 .. _GitHub: https://github.com/wlanslovenija/tunneldigger
-.. _development mailing list: https://wlan-si.net/lists/info/development
+.. _Issue tracker: https://github.com/wlanslovenija/tunneldigger/issues
 
-Contributors
-------------
+License
+-------
 
-* `@kostko`_
-* `@lynxis`_
-* `@mitar`_
-* `@max-b`_
-* `@mehlix`_
-* `@valentt`_
-* `@papazoga`_
+Tunneldigger is licensed under AGPLv3_.
 
-.. _@kostko: https://github.com/kostko
-.. _@lynxis: https://github.com/lynxis
-.. _@mitar: https://github.com/mitar
-.. _@max-b: https://github.com/max-b
-.. _@mehlix: https://github.com/mehlis
-.. _@valentt: https://github.com/valentt
-.. _@papazoga: https://github.com/papazoga
+.. _AGPLv3: https://www.gnu.org/licenses/agpl-3.0.en.html
+
+Contributions
+-------------
+
+We welcome code and documentation contributions to Tunneldigger in the form of
+`Pull Requests`_ on GitHub where they can be reviewed and discussed by the
+community.
+We encourage everyone to check out any pending pull requests and offer comments
+or ideas as well.
+
+.. _Pull Requests: https://github.com/wlanslovenija/tunneldigger/pulls
+
+Tunneldigger is developed by a community of developers from many different
+backgrounds.
+
+You can visualize all code contributions using `GitHub Insights`_.
+
+.. _GitHub Insights: https://github.com/wlanslovenija/tunneldigger/graphs/contributors


### PR DESCRIPTION
Apart from changing the links in the license files to HTTPS the README.rst
got updated:
- improved structure
- removal of obsolete links to wlan-si
- mention GitHub as primary development platform
- include license info
- include contributions info
- remove listing of individual contributors
- refer to GitHub insights for authorship info

Signed-off-by: Felix Kaechele <felix@kaechele.ca>

**NOTE:** The removal of the individual contributors may be controversial. However, since that list will probably always be outdated anyway, I recommend just referring people to the commit stats of the repository.
