### PR TITLE
l2tp_client: allow to set MAX_BROKERS from outside

### DIFF
--- a/client/l2tp_client.c
+++ b/client/l2tp_client.c
@@ -236,7 +236,9 @@ typedef struct {
 } broker_cfg;
 
 // Maximum number of brokers that can be handled in a single process.
-#define MAX_BROKERS 10
+#ifndef MAX_BROKERS
+  #define MAX_BROKERS 10
+#endif
 
 // Forward declarations.
 void context_delete_tunnel(l2tp_context *ctx);

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -23,3 +23,10 @@ package. Source code for such OpenWrt package can be `found here`_.
 .. _OpenWrt: https://openwrt.org/
 
 You can add the whole repository as an OpenWrt feed and add package to your firmware.
+
+Configuration
+-------------
+
+* **MAX_BROKERS** (default: 10): Maximum number of brokers that can be handled in a single process.
+
+    make CFLAGS="-D MAX_BROKERS=20"


### PR DESCRIPTION
For certain environments 10 brokers are not enought. Allow to
overwrite this value.
make CFLAGS="-D MAX_BROKERS=254"