### PR TITLE
client: dont send PMTU_NTFY when we do not actually have a sensible PMTU

### DIFF
--- a/client/l2tp_client.c
+++ b/client/l2tp_client.c
@@ -1199,13 +1199,13 @@ void context_process(l2tp_context *ctx)
           ctx->pmtu = ctx->probed_pmtu;
           context_session_set_mtu(ctx);
         }
-
-        // Notify the broker of the configured MTU.
-        char buffer[16];
-        char *buf = buffer;
-        put_u16(&buf, ctx->pmtu - L2TP_TUN_OVERHEAD);
-        context_send_packet(ctx, CONTROL_TYPE_PMTU_NTFY, (char*) &buffer, 2);
-
+        if (ctx->pmtu > 0) {
+          // Notify the broker of the configured MTU.
+          char buffer[16];
+          char *buf = buffer;
+          put_u16(&buf, ctx->pmtu - L2TP_TUN_OVERHEAD);
+          context_send_packet(ctx, CONTROL_TYPE_PMTU_NTFY, (char*) &buffer, 2);
+        }
         ctx->probed_pmtu = 0;
         ctx->timer_pmtu_collect = -1;
         ctx->timer_pmtu_xmit = -1;

--- a/client/l2tp_client.c
+++ b/client/l2tp_client.c
@@ -999,7 +999,11 @@ int context_setup_tunnel(l2tp_context *ctx, uint32_t peer_tunnel_id, uint32_t se
 
 int context_session_set_mtu(l2tp_context *ctx)
 {
-  uint16_t mtu = ctx->pmtu - L2TP_TUN_OVERHEAD;
+  if (ctx->pmtu == 0 && ctx->peer_pmtu == 0)
+    return 0;
+  uint16_t mtu = 0xFFFF;
+  if (ctx->pmtu > 0)
+    mtu = ctx->pmtu - L2TP_TUN_OVERHEAD;
   if (ctx->peer_pmtu > 0 && ctx->peer_pmtu < mtu)
     mtu = ctx->peer_pmtu;
   syslog(LOG_INFO, "[%s:%s] Setting MTU to %d", ctx->broker_hostname, ctx->broker_port, (int) mtu);


### PR DESCRIPTION
I noticed clients are sending CONTROL_TYPE_PMTU_NTFY with silly PMTUs (0 - L2TP_TUN_OVERHEAD overflows). This PR should stop that.