### PR TITLE
check for endpoint change on all messages, not just CREATE_TUNNEL

### DIFF
--- a/broker/src/tunneldigger_broker/tunnel.py
+++ b/broker/src/tunneldigger_broker/tunnel.py
@@ -288,10 +288,6 @@ class Tunnel(protocol.HandshakeProtocolMixin, network.Pollable):
         control message.
         """
 
-        if address != self.endpoint:
-            logger.warning("Protocol error: tunnel endpoint has changed. Possibly due to kernel bug. See: https://github.com/wlanslovenija/tunneldigger/issues/126")
-            return False
-
         if uuid != self.uuid:
             logger.warning("Protocol error: tunnel UUID has changed.")
             return False
@@ -318,6 +314,10 @@ class Tunnel(protocol.HandshakeProtocolMixin, network.Pollable):
         :param msg_data: Message payload
         :param raw_length: Length of the raw message (including headers)
         """
+
+        if address != self.endpoint:
+            logger.warning("Protocol error: tunnel endpoint has changed. Possibly due to kernel bug. See: https://github.com/wlanslovenija/tunneldigger/issues/126")
+            return False
 
         if super(Tunnel, self).message(address, msg_type, msg_data, raw_length):
             return True


### PR DESCRIPTION
This check can be done for all messages, and with broken kernels it can indeed go wrong for all messages, to check it properly.