### PR TITLE
see if changing keyserver helps with CI issues

### DIFF
--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -22,6 +22,7 @@ if [ "$OLD_REV" = "HEAD" ] ; then
 fi
 
 # finish setup
+export DOWNLOAD_KEYSERVER="keyserver.ubuntu.com" # we had a lot of intermittent failures with the default keyserver
 $(dirname $0)/tunneldigger.py --setup bionic
 if [[ "$OLD_UBUNTU" == "trusty" || "$SELECT" == "usage" ]]; then
     $(dirname $0)/tunneldigger.py --setup trusty

--- a/tests/tunneldigger.py
+++ b/tests/tunneldigger.py
@@ -25,10 +25,10 @@ def setup_template(ubuntu_release):
     container = lxc.Container("tunneldigger-base-{}".format(ubuntu_release))
 
     if not container.defined:
-        for i in range(0, 10): # retry a few times, this tends to fail spuriously on travis
+        for i in range(0, 5): # retry a few times, this tends to fail spuriously on travis
             if container.create("download", args={"dist": "ubuntu", "release": ubuntu_release, "arch": "amd64"}):
                 break
-            sleep(5) # wait a bit before next attempt
+            sleep(10) # wait a bit before next attempt
         else:
             raise RuntimeError("failed to create container")
 


### PR DESCRIPTION
I was finally able to get an error message for the failed LXC installs:

> ERROR: Unable to fetch GPG key from keyserver

So let's try setting a hopefully-good keyserver. Also spam it a bit less.