### PR TITLE
switch per per-IP to per-UUID rate limiting

### DIFF
--- a/broker/l2tp_broker.cfg.example
+++ b/broker/l2tp_broker.cfg.example
@@ -14,11 +14,11 @@ tunnel_id_base=100
 ; Reject connections if there are less than N seconds since the last connection.
 ; Can be less than a second (e.g., 0.1).
 connection_rate_limit=0.2
-; Reject connection if an IP address connects more than COUNT times in TIME seconds. Also runs
+; Reject connection if a UUID connects more than COUNT times in TIME seconds. Also runs
 ; "broker.connection-rate-limit" hook (e.g. to block client via iptables).
 ; Disabled when at least one value is 0 (the default).
-;connection_rate_limit_per_ip_count=20
-;connection_rate_limit_per_ip_time=60
+;connection_rate_limit_per_uuid_count=20
+;connection_rate_limit_per_uuid_time=60
 ; Set PMTU to a fixed value.  Use 0 for automatic PMTU discovery.  A non-0 value also disables
 ; PMTU discovery on the client side, by having the server not respond to client-side PMTU
 ; discovery probes.
@@ -52,5 +52,5 @@ session.pre-down=
 session.down=
 ; Called after the tunnel MTU gets changed because of PMTU discovery
 session.mtu-changed=
-; Called when the tunnel connection rate per ip limit is exceeded
+; Called when the tunnel connection rate per UUID limit is exceeded
 broker.connection-rate-limit=

--- a/broker/src/tunneldigger_broker/main.py
+++ b/broker/src/tunneldigger_broker/main.py
@@ -76,8 +76,8 @@ tunnel_manager = broker.TunnelManager(
     max_tunnels=config.getint('broker', 'max_tunnels'),
     tunnel_id_base=config.getint('broker', 'tunnel_id_base'),
     connection_rate_limit=config.getfloat('broker', 'connection_rate_limit'),
-    connection_rate_limit_per_ip_count=config.getint('broker', 'connection_rate_limit_per_ip_count', fallback=0),
-    connection_rate_limit_per_ip_time=config.getfloat('broker', 'connection_rate_limit_per_ip_time', fallback=0),
+    connection_rate_limit_per_uuid_count=config.getint('broker', 'connection_rate_limit_per_uuid_count', fallback=0),
+    connection_rate_limit_per_uuid_time=config.getfloat('broker', 'connection_rate_limit_per_uuid_time', fallback=0),
     pmtu_fixed=config.getint('broker', 'pmtu'),
     log_ip_addresses=config.getboolean('log', 'log_ip_addresses'),
 )

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -204,8 +204,8 @@ There are currently four different hooks, namely:
 * ``session.mtu-changed`` is called after the broker's path MTU discovery determines that the tunnel's MTU has changed
   and should be adjusted. (Example is found under ``scripts/mtu_changed.sh``.)
 
-* ``broker.connection-rate-limit`` is called when a IP address tries to connect ``connection_rate_limit_per_ip_count``
-  times within ``connection_rate_limit_per_ip_time`` seconds. (Example is found under ``scripts/broker.connection-rate-limit.sh``.)
+* ``broker.connection-rate-limit`` is called when a UUID address tries to connect ``connection_rate_limit_per_uuid_count``
+  times within ``connection_rate_limit_per_uuid_time`` seconds. (Example is found under ``scripts/broker.connection-rate-limit.sh``.)
 
 Please look at all the example hook scripts carefully and try to understand
 them before use. They should be considered configuration and some things in


### PR DESCRIPTION
I rolled out per-IP rate limiting in our network, but it turns out that even rates as low as 20 connections per 10 minutes are problematic. I am not sure what exactly these misbehaving clients are doing; probably the actual issue is not the load caused by these connection attempts but by other things they do.

Doing the limiting per-UUID lets me reduce the threshhold to something like "max 5 connections per 2 minutes". I would not want to do that per-IP, because people might run 5 nodes behind the same IP and then that limit is reached too easily.

Cc @RobWei does per-UUID rate limiting work for you, or do you require a per-IP limit?

Fixes https://github.com/wlanslovenija/tunneldigger/issues/144