### PR TITLE
close pollable when its FD errors

### DIFF
--- a/broker/src/tunneldigger_broker/eventloop.py
+++ b/broker/src/tunneldigger_broker/eventloop.py
@@ -57,7 +57,7 @@ class EventLoop(object):
 
                     if event & select.EPOLLIN:
                         pollable.read(file_object)
-                    elif event & select.EPOLLERR:
+                    elif event & select.EPOLLERR or event & select.EPOLLHUP:
                         pollable.close()
             except IOError:
                 # IOError get produced by signal even. in version 3.5 this is fixed an the poll retries

--- a/broker/src/tunneldigger_broker/eventloop.py
+++ b/broker/src/tunneldigger_broker/eventloop.py
@@ -57,6 +57,8 @@ class EventLoop(object):
 
                     if event & select.EPOLLIN:
                         pollable.read(file_object)
+                    elif event & select.EPOLLERR:
+                        pollable.close()
             except IOError:
                 # IOError get produced by signal even. in version 3.5 this is fixed an the poll retries
                 # TODO: in py3 it's InterruptedError


### PR DESCRIPTION
When an FD errors, `epoll` returns immediately reporting the error. This leads to a tight loop (instead of epoll waiting until there is a new event), causing very high load (https://github.com/wlanslovenija/tunneldigger/issues/143). So we should stop polling FDs once they error. This PR achieves that by simply closing the associated pollable.

I checked that on our server with a misbehaving client whose connections keep dropping this reduces the load from 100% to basically nothing.

Fixes https://github.com/wlanslovenija/tunneldigger/issues/143.