### PR TITLE
handle hook process being closed twice

### DIFF
--- a/broker/src/tunneldigger_broker/hooks.py
+++ b/broker/src/tunneldigger_broker/hooks.py
@@ -55,6 +55,10 @@ class HookProcess(object):
         Closes the hook process.
         """
 
+        if not hasattr(self, "buffer"):
+            # We have already been closed.
+            return
+
         for line in self.buffer.getvalue().decode('utf-8').split('\n'):
             if not line:
                 continue


### PR DESCRIPTION
After merging https://github.com/wlanslovenija/tunneldigger/pull/148, I started seeing exceptions terminating the broker on one (the slowest) of our servers. Seems like reacting to EPOLLHUP means we now close some things twice, which the `HookProcess` class did not handle well. This fixes the exceptions, but I am not sure if it is a proper fix.