### PR TITLE
Made interface to an optional parameter

### DIFF
--- a/broker/src/tunneldigger_broker/main.py
+++ b/broker/src/tunneldigger_broker/main.py
@@ -91,11 +91,18 @@ brokers = []
 broker_host = config.get('broker', 'address')
 for port in config.get('broker', 'port').split(','):
     try:
-        broker_instance = broker.Broker(
-            (broker_host, int(port)),
-            config.get('broker', 'interface'),
-            tunnel_manager,
-        )
+        if config.has_option('broker', 'interface'):
+            broker_instance = broker.Broker(
+                (broker_host, int(port)),
+                config.get('broker', 'interface'),
+                tunnel_manager,
+            )
+        else:
+            broker_instance = broker.Broker(
+                (broker_host, int(port)),
+                None,
+                tunnel_manager,
+            )
         logger.info("Listening on %s:%d." % broker_instance.address)
     except ValueError:
         logger.warning("Malformed port number '%s', skipping." % port)

--- a/broker/src/tunneldigger_broker/network.py
+++ b/broker/src/tunneldigger_broker/network.py
@@ -36,7 +36,8 @@ class Pollable(object):
         # Since we want all tunnel and tunnel control traffic to use the same port for
         # all clients we enable reuse of ports on the sockets we create.
         self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
-        self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_BINDTODEVICE, interface.encode('utf-8'))
+        if interface is not None:
+            self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_BINDTODEVICE, interface.encode('utf-8'))
         self.socket.bind(address)
 
         self.address = address


### PR DESCRIPTION
Since we are now running a tunneligger broker instance on a routed IP address, I noticed that the tunneligger does not work with a loopback interface.

To the basic structure:
Our IPv4 subnet is announced via BGP on several interfaces. An IP from the subnet is configured on the loopback interface.

A short analysis of the pollable object showed that the UDP socket is bound to an interface.  I could not find out why this was done.

This change allows to define interfaces optionally.