### PR TITLE
update sample scripts to use iproute

### DIFF
--- a/broker/scripts/bridge_functions.sh
+++ b/broker/scripts/bridge_functions.sh
@@ -7,7 +7,7 @@ ensure_policy()
 ensure_bridge()
 {
   local brname="$1"
-  brctl addbr $brname 2>/dev/null
+  ip link add $brname type bridge 2>/dev/null
   
   if [[ "$?" == "0" ]]; then
     # Bridge did not exist before, we have to initialize it
@@ -16,8 +16,6 @@ ensure_bridge()
     ip addr add 10.254.0.2/16 dev $brname
     # TODO Policy routing should probably not be hardcoded here?
     ensure_policy from all iif $brname lookup mesh prio 1000
-    # Disable forwarding between bridge ports
-    ebtables -A FORWARD --logical-in $brname -j DROP
   fi
 }
 

--- a/broker/scripts/session.down.sh
+++ b/broker/scripts/session.down.sh
@@ -9,5 +9,5 @@ UUID="$8"
 LOCAL_BROKER_PORT="$9"
 
 # Remove the interface from our bridge
-brctl delif digger${MTU} $INTERFACE
+ip link set dev $INTERFACE nomaster
 

--- a/broker/scripts/session.mtu-changed.sh
+++ b/broker/scripts/session.mtu-changed.sh
@@ -7,12 +7,8 @@ NEW_MTU="$5"
 . scripts/bridge_functions.sh
 
 # Remove interface from old bridge
-brctl delif digger${OLD_MTU} $INTERFACE
+ip link set dev $INTERFACE nomaster
 
-# Change interface MTU
-ip link set dev $INTERFACE mtu $NEW_MTU
-
-# Add interface to new bridge
+# Change interface MTU and add to new bridge
 ensure_bridge digger${NEW_MTU}
-brctl addif digger${NEW_MTU} $INTERFACE
-
+ip link set dev $INTERFACE master digger${NEW_MTU} mtu $NEW_MTU up

--- a/broker/scripts/session.up.sh
+++ b/broker/scripts/session.up.sh
@@ -11,10 +11,9 @@ LOCAL_BROKER_PORT="$9"
 
 . scripts/bridge_functions.sh
 
-# Set the interface to UP state
-ip link set dev $INTERFACE up mtu $MTU
-
 # Add the interface to our bridge
 ensure_bridge digger${MTU}
-brctl addif digger${MTU} $INTERFACE
+ip link set dev $INTERFACE master digger${MTU} mtu $MTU up
 
+# Turn on bridge port isolation
+bridge link set dev $INTERFACE isolated on


### PR DESCRIPTION
Old `ioctl` based tools like `brctl` are deprecated and have been
removed from the default package set of some distributions.

Also drop usage of ebtables in favour of native bridge port isolation
available in kernels 4.18 and newer.

Signed-off-by: Felix Kaechele <felix@kaechele.ca>