### PR TITLE
move socket read error handling logic around a bit

### DIFF
--- a/broker/src/tunneldigger_broker/eventloop.py
+++ b/broker/src/tunneldigger_broker/eventloop.py
@@ -54,10 +54,10 @@ class EventLoop(object):
 
                     pollable, file_object = mapping
 
-                    if event & select.EPOLLIN:
+                    if event & select.EPOLLIN or event & select.EPOLLERR or event & select.EPOLLHUP:
+                        # If there's anything new, we read. If there was an error, the read will
+                        # return that error so we can handle it.
                         pollable.read(file_object)
-                    elif event & select.EPOLLERR or event & select.EPOLLHUP:
-                        pollable.error()
             except IOError:
                 # IOError get produced by signal even. in version 3.5 this is fixed an the poll retries
                 # TODO: in py3 it's InterruptedError

--- a/broker/src/tunneldigger_broker/hooks.py
+++ b/broker/src/tunneldigger_broker/hooks.py
@@ -50,9 +50,6 @@ class HookProcess(object):
         event_loop.register(self, self.process.stderr, select.EPOLLIN)
         self.event_loop = event_loop
 
-    def error(self):
-        self.close()
-
     def close(self):
         """
         Closes the hook process.
@@ -162,9 +159,6 @@ class HookManager(object):
             self.processes[process.process.pid] = process
         except OSError as e:
             logger.error("Error while executing script '%s': %s" % (script, e))
-
-    def error(self):
-        self.close()
 
     def close(self):
         os.close(self.sigchld_fd)


### PR DESCRIPTION
We always `read` when epoll says there is an error waiting. Then `read` will dispatch to `error` to get handling suitable for the specific socket. For `Tunnel` we avoid doing anything (logging or counting the error) for EMSGSIZE.

I realized we are entirely ignoring write errors, so I made them feed the same mechanism.

@mitar is that along the lines of what you had in mind?