### PR TITLE
client: set cmake_minimum_required to 3.10

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.10)
 project (tunneldigger C)
 
 set(USE_LIBNL FALSE CACHE BOOL "Explicitly use libnl over libnl-tiny")


### PR DESCRIPTION
New cmake versions require at least 3.5 as 'cmake_minimum_required' in CMakeLists.txt. In future 3.10 will be required.